### PR TITLE
Add 4 more PII columns

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -200,9 +200,9 @@ def remove_casework_letters(input_dir):
 def remove_pii(df):
     """Remove columns with personally identifiable information (name and address) if they are present"""
 
-    # List of column names that should be removed. Includes names and address information.
+    # List of column names that should be removed because they include names or addresses.
     remove = ['prefix', 'first', 'middle', 'last', 'suffix', 'appellation', 'title', 'org',
-              'addr1', 'addr2', 'addr3', 'addr4']
+              'addr1', 'addr2', 'addr3', 'addr4', 'in_text', 'in_fillin', 'out_text', 'out_fillin']
 
     # Removes every column on the remove list from the dataframe, if they are present.
     # Nothing happens, due to errors="ignore", if any are not present.

--- a/tests/css_archiving_format/test_remove_pii.py
+++ b/tests/css_archiving_format/test_remove_pii.py
@@ -14,9 +14,10 @@ class MyTestCase(unittest.TestCase):
         """Test for when all PII columns are present."""
         # Makes a dataframe to use as test input.
         md_df = pd.DataFrame([['1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-                               '11', '12', '13', '14', '15', '16', '17']],
+                               '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21']],
                              columns=['prefix', 'first', 'middle', 'last', 'suffix', 'appellation', 'title', 'org',
-                                      'addr1', 'addr2', 'addr3', 'addr4', 'city', 'state', 'zip', 'in_id', 'out_id'])
+                                      'addr1', 'addr2', 'addr3', 'addr4', 'city', 'state', 'zip', 'in_id', 'in_text',
+                                      'in_fillin', 'out_id', 'out_text', 'out_fillin'])
         md_df = remove_pii(md_df)
 
         # Tests the columns of the returned dataframe are correct.
@@ -24,7 +25,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for all present, columns")
 
         # Tests the values in the returned dataframe are correct.
-        expected = [['13', '14', '15', '16', '17']]
+        expected = [['13', '14', '15', '16', '19']]
         self.assertEqual(md_df.values.tolist(), expected, "Problem with test for all present, values")
 
     def test_some_present(self):

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -80,42 +80,42 @@ class MyTestCase(unittest.TestCase):
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_redacted.csv')
         result = csv_to_list(csv_path)
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
-                     'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
-                     'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin'],
-                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1', 'nan',
-                     r'..\documents\BlobExport\objects\111111.txt', 'nan', 'r100', 'General', 'Email', '20210111',
-                     'A', 'nan', r'..\documents\BlobExport\formletters\A', 'nan'],
-                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2', 'Note',
-                     r'..\documents\BlobExport\objects\222222.txt', 'nan', 'r200', 'General', 'Email', '20230212',
-                     'B', 'nan', r'..\documents\BlobExport\formletters\B', 'nan'],
-                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1', 'nan',
-                     r'..\documents\BlobExport\objects\333333.txt', 'nan', 'r300', 'General', 'Email', '20240313',
-                     'A', 'nan', r'..\documents\BlobExport\formletters\A', 'nan']]
+                     'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method', 'out_date',
+                     'out_topic', 'out_document_name'],
+                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1',
+                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', '20210111',
+                     'A', r'..\documents\BlobExport\formletters\A'],
+                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2',
+                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', '20230212',
+                     'B', r'..\documents\BlobExport\formletters\B'],
+                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1',
+                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', '20240313',
+                     'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
 
         # Tests the contents of 2021-2022.csv.
         csv_path = os.path.join('test_data', 'script', '2021-2022.csv')
         result = csv_to_list(csv_path)
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
-                     'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
-                     'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin'],
-                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1', 'nan',
-                     r'..\documents\BlobExport\objects\111111.txt', 'nan', 'r100', 'General', 'Email', '20210111',
-                     'A', 'nan', r'..\documents\BlobExport\formletters\A', 'nan']]
+                     'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
+                     'out_date', 'out_topic', 'out_document_name'],
+                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1',
+                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', '20210111',
+                     'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, 2021-2022.csv")
 
         # Tests the contents of 2023-2024.csv.
         csv_path = os.path.join(os.getcwd(), 'test_data', 'script', '2023-2024.csv')
         result = csv_to_list(csv_path)
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
-                     'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
-                     'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin'],
-                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2', 'Note',
-                     r'..\documents\BlobExport\objects\222222.txt', 'nan', 'r200', 'General', 'Email', '20230212',
-                     'B', 'nan', r'..\documents\BlobExport\formletters\B', 'nan'],
-                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1', 'nan',
-                     r'..\documents\BlobExport\objects\333333.txt', 'nan', 'r300', 'General', 'Email', '20240313',
-                     'A', 'nan', r'..\documents\BlobExport\formletters\A', 'nan']]
+                     'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
+                     'out_date', 'out_topic', 'out_document_name'],
+                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2',
+                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', '20230212',
+                     'B', r'..\documents\BlobExport\formletters\B'],
+                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1',
+                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', '20240313',
+                     'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, 2023-2024.csv")
 
         # Tests that no undated.csv was made.


### PR DESCRIPTION
For css_archiving_format.py, remove 4 additional PII columns: in_text, in_fillin, out_text, and out_fillin