### PR TITLE
Check arg caps

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -37,9 +37,9 @@ def check_arguments(arg_list):
     if len(arg_list) > 1:
         if os.path.exists(arg_list[1]):
             input_dir = arg_list[1]
-            if os.path.exists(os.path.join(input_dir, 'archiving_correspondence.dat')):
+            if 'archiving_correspondence.dat' in os.listdir(input_dir):
                 md_path = os.path.join(input_dir, 'archiving_correspondence.dat')
-            elif os.path.exists(os.path.join(input_dir, 'archiving_correspondence.dat')):
+            elif 'archiving_CORRESPONDENCE.dat' in os.listdir(input_dir):
                 md_path = os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat')
             else:
                 errors.append(f"No archiving_correspondence.dat file in the input_directory")

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -26,13 +26,13 @@ class MyTestCase(unittest.TestCase):
     def test_correct_accession(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is accession."""
         # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct_caps')
         sys_argv = ['css_archiving_format.py', input_dir, 'accession']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
         self.assertEqual(input_directory, input_dir, "Problem with correct - accession, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'),
                          "Problem with correct - accession, metadata_path")
         self.assertEqual(script_mode, 'accession', "Problem with correct - accession, script_mode")
         self.assertEqual(errors_list, [], "Problem with correct - accession, errors_list")
@@ -54,13 +54,13 @@ class MyTestCase(unittest.TestCase):
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is preservation."""
         # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct_caps')
         sys_argv = ['css_archiving_format.py', input_dir, 'preservation']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
         self.assertEqual(input_directory, input_dir, "Problem with correct - preservation, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'),
                          "Problem with correct - preservation, metadata_path")
         self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
         self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")

--- a/tests/css_archiving_format/test_data/check_arguments/correct_caps/archiving_CORRESPONDENCE.dat
+++ b/tests/css_archiving_format/test_data/check_arguments/correct_caps/archiving_CORRESPONDENCE.dat
@@ -1,0 +1,1 @@
+Placeholder for check_arguments() tests that needs a valid path for a DAT file.


### PR DESCRIPTION
Fix error in how check_arguments() finds the path for archiving_CORRESPONDENCE.dat. It wasn't actually working when the file is caps, which is a variation we see in real exports.