### PR TITLE
Csv to list

### DIFF
--- a/tests/css_archiving_format/test_check_letter_matching.py
+++ b/tests/css_archiving_format/test_check_letter_matching.py
@@ -7,16 +7,7 @@ import os
 import pandas as pd
 import unittest
 from css_archiving_format import check_letter_matching
-
-
-def csv_to_list(csv_path, sort=False):
-    """Convert the contents of a CSV to a list which contains one list per row for easier comparison,
-    with the detailed report sorted by both columns because the input has inconsistent order"""
-    df = pd.read_csv(csv_path)
-    if sort:
-        df = df.sort_values(by=['Category', 'Path'])
-    csv_list = [df.columns.tolist()] + df.values.tolist()
-    return csv_list
+from test_script import csv_to_list
 
 
 class MyTestCase(unittest.TestCase):

--- a/tests/css_archiving_format/test_check_metadata_formatting.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting.py
@@ -10,7 +10,7 @@ import os
 import pandas as pd
 import unittest
 from css_archiving_format import check_metadata_formatting
-from test_check_metadata_usability import csv_to_list
+from test_script import csv_to_list
 
 
 class MyTestCase(unittest.TestCase):

--- a/tests/css_archiving_format/test_check_metadata_formatting_multi.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting_multi.py
@@ -10,7 +10,7 @@ import os
 import pandas as pd
 import unittest
 from css_archiving_format import check_metadata_formatting_multi
-from test_check_metadata_usability import csv_to_list
+from test_script import csv_to_list
 
 
 class MyTestCase(unittest.TestCase):

--- a/tests/css_archiving_format/test_check_metadata_usability.py
+++ b/tests/css_archiving_format/test_check_metadata_usability.py
@@ -8,14 +8,7 @@ import os
 import pandas as pd
 import unittest
 from css_archiving_format import check_metadata_usability
-
-
-def csv_to_list(csv_path):
-    """Convert the contents of a CSV to a list which contains one list per row for easier comparison"""
-    df = pd.read_csv(csv_path)
-    df = df.fillna('blank')
-    csv_list = [df.columns.tolist()] + df.values.tolist()
-    return csv_list
+from test_script import csv_to_list
 
 
 def make_df(rows_list):
@@ -187,7 +180,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', 'True', 0, 0.0, 'uncheckable'],
                     ['out_document_name', 'True', 0, 0.0, '0'],
                     ['out_fillin', 'True', 0, 0.0, 'uncheckable'],
-                    ['extra', 'Error: unexpected column', 0, 0.0, 'blank']]
+                    ['extra', 'Error: unexpected column', 0, 0.0, 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for extra")
 
     def test_columns_format(self):
@@ -261,8 +254,8 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the metadata usability report are correct.
         result = csv_to_list(os.path.join('test_data', 'usability_report_metadata.csv'))
         expected = [['Column_Name', 'Present', 'Blank_Count', 'Blank_Percent', 'Formatting_Errors'],
-                    ['prefix', False, 'blank', 'blank', 'uncheckable'],
-                    ['first', False, 'blank', 'blank', 'uncheckable'],
+                    ['prefix', False, 'BLANK', 'BLANK', 'uncheckable'],
+                    ['first', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['middle', True, 0.0, 0.0, 'uncheckable'],
                     ['last', True, 0.0, 0.0, 'uncheckable'],
                     ['suffix', True, 0.0, 0.0, 'uncheckable'],
@@ -270,8 +263,8 @@ class MyTestCase(unittest.TestCase):
                     ['title', True, 0.0, 0.0, 'uncheckable'],
                     ['org', True, 0.0, 0.0, 'uncheckable'],
                     ['addr1', True, 0.0, 0.0, 'uncheckable'],
-                    ['addr2', False, 'blank', 'blank', 'uncheckable'],
-                    ['addr3', False, 'blank', 'blank', 'uncheckable'],
+                    ['addr2', False, 'BLANK', 'BLANK', 'uncheckable'],
+                    ['addr3', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['addr4', True, 0.0, 0.0, 'uncheckable'],
                     ['city', True, 0.0, 0.0, 'uncheckable'],
                     ['state', True, 0.0, 0.0, '0'],
@@ -279,9 +272,9 @@ class MyTestCase(unittest.TestCase):
                     ['country', True, 0.0, 0.0, 'uncheckable'],
                     ['in_id', True, 0.0, 0.0, 'uncheckable'],
                     ['in_type', True, 0.0, 0.0, 'uncheckable'],
-                    ['in_method', False, 'blank', 'blank', 'uncheckable'],
+                    ['in_method', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['in_date', True, 0.0, 0.0, '0'],
-                    ['in_topic', False, 'blank', 'blank', 'uncheckable'],
+                    ['in_topic', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['in_text', True, 0.0, 0.0, 'uncheckable'],
                     ['in_document_name', True, 0.0, 0.0, '0'],
                     ['in_fillin', True, 0.0, 0.0, 'uncheckable'],
@@ -290,9 +283,9 @@ class MyTestCase(unittest.TestCase):
                     ['out_method', True, 0.0, 0.0, 'uncheckable'],
                     ['out_date', True, 0.0, 0.0, '0'],
                     ['out_topic', True, 0.0, 0.0, 'uncheckable'],
-                    ['out_text', False, 'blank', 'blank', 'uncheckable'],
+                    ['out_text', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['out_document_name', True, 0.0, 0.0, '0'],
-                    ['out_fillin', False, 'blank', 'blank', 'uncheckable']]
+                    ['out_fillin', False, 'BLANK', 'BLANK', 'uncheckable']]
         self.assertEqual(result, expected, "Problem with test for missing")
 
 

--- a/tests/css_archiving_format/test_delete_appraisal_letters.py
+++ b/tests/css_archiving_format/test_delete_appraisal_letters.py
@@ -56,9 +56,9 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'..\documents\objects\111111.txt'.replace('..', input_dir),
-                     '0.2', today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
+                     0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\objects\222222.txt'.replace('..', input_dir),
-                     '0.7', today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'],]
+                     0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'],]
         self.assertEqual(result, expected, "Problem with test for in_document_name, file deletion log")
 
         # Tests the contents of the input_dir, that all files that should be deleted are gone.
@@ -87,9 +87,9 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'..\documents\indivletters\400.txt'.replace('..', input_dir),
-                     '2.4', today, today, '4CF163BB5919075DD6FEB7FC8D2AF3A8', 'Casework'],
+                     2.4, today, today, '4CF163BB5919075DD6FEB7FC8D2AF3A8', 'Casework'],
                     [r'..\documents\indivletters\500.txt'.replace('..', input_dir),
-                     '1.8', today, today, '64ADE70B27A5D7923C5D3805B5671668', 'Casework'], ]
+                     1.8, today, today, '64ADE70B27A5D7923C5D3805B5671668', 'Casework'], ]
         self.assertEqual(result, expected, "Problem with test for out_document_name blobexport, file deletion log")
 
         # Tests the contents of the input_dir, that all files that should be deleted are gone.
@@ -119,9 +119,9 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'..\documents\letter\111111.txt'.replace('..', input_dir),
-                     '0.2', today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
+                     0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\letter\333333.txt'.replace('..', input_dir),
-                     '0.7', today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
+                     0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
         self.assertEqual(result, expected, "Problem with test for out_document_name dos, file deletion log")
 
         # Tests the contents of the input_dir, that all files that should be deleted are gone.
@@ -146,9 +146,9 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'..\documents\objects\111111.txt'.replace('..', input_dir),
-                     'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError'],
+                     'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\indivletters\500.txt'.replace('..', input_dir),
-                     'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError']]
+                     'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
         self.assertEqual(result, expected, "Problem with test for file deletion log")
 
 

--- a/tests/css_archiving_format/test_file_deletion_log.py
+++ b/tests/css_archiving_format/test_file_deletion_log.py
@@ -37,8 +37,8 @@ class MyTestCase(unittest.TestCase):
         today = date.today().strftime('%Y-%m-%d')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [file_path_1, '0.0', '2025-02-24', today, '89D31DC38A6C7D68653F452A2F44AC3D', 'Academy_Application'],
-                    [file_path_2, '1.2', '2025-02-24', today, '9452DF84756C849AE0ED9FE2A14948F5', 'Casework']]
+                    [file_path_1, 0.0, '2025-02-24', today, '89D31DC38A6C7D68653F452A2F44AC3D', 'Academy_Application'],
+                    [file_path_2, 1.2, '2025-02-24', today, '9452DF84756C849AE0ED9FE2A14948F5', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for delete two")
 
     def test_filenotfounderror(self):
@@ -56,7 +56,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [file_path, 'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError']]
+                    [file_path, 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
         self.assertEqual(result, expected, "Problem with test for filenotfounderror")
 
     def test_header(self):

--- a/tests/css_archiving_format/test_find_appraisal_rows.py
+++ b/tests/css_archiving_format/test_find_appraisal_rows.py
@@ -52,20 +52,20 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', 'nan', 'nan', 'nan', 'Academy_Application'],
-                    ['30602', 'Casework', 'nan', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30603', 'Admin', 'nan', 'Recommendations', 'wrote recommendation', 'nan', 'Recommendation'],
-                    ['30604', 'Social Security', 'Casework candidate', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30605', 'Intern', 'nan', 'job request', 'nan', r'..\doc\resume.txt', 'Job_Application']]
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
+                    [30602, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Admin', 'BLANK', 'Recommendations', 'wrote recommendation', 'BLANK', 'Recommendation'],
+                    [30604, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30605, 'Intern', 'BLANK', 'job request', 'BLANK', r'..\doc\resume.txt', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30608', 'Arts', 'International Academy', 'nan', 'nan', 'nan', 'Academy_Application'],
-                    ['30609', 'Legal', 'Case against Napster', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30606', 'Congratulations', 'nan', 'nan', 'nan', 'Good job', 'Job_Application'],
-                    ['30607', 'Legislation', 'nan', 'nan', 'nan', 'Recommendation noted', 'Recommendation']]
+                    [30608, 'Arts', 'International Academy', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
+                    [30609, 'Legal', 'Case against Napster', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30606, 'Congratulations', 'BLANK', 'BLANK', 'BLANK', 'Good job', 'Job_Application'],
+                    [30607, 'Legislation', 'BLANK', 'BLANK', 'BLANK', 'Recommendation noted', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_three(self):
@@ -92,16 +92,16 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', 'nan', 'nan', 'nan', 'Academy_Application'],
-                    ['30601', 'Casework', 'nan', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30603', 'Social Security', 'Casework candidate', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30604', 'Intern', 'nan', 'job request', 'nan', r'..\doc\resume.txt', 'Job_Application']]
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
+                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30604, 'Intern', 'BLANK', 'job request', 'BLANK', r'..\doc\resume.txt', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for three categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30605', 'Judicial', 'Napster case', 'nan', 'nan', 'nan', 'Casework']]
+                    [30605, 'Judicial', 'Napster case', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_two(self):
@@ -127,16 +127,16 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', 'nan', 'nan', 'nan', 'Academy_Application'],
-                    ['30601', 'Casework', 'nan', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30603', 'Social Security', 'Casework candidate', 'nan', 'nan', 'nan', 'Casework']]
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
+                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for two categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30604', 'Culture', 'Academy Awards', 'nan', 'nan', 'nan', 'Academy_Application'],
-                    ['30605', 'Farming', 'nan', 'nan', 'nan', r'..\doc\case\file.doc', 'Casework']]
+                    [30604, 'Culture', 'Academy Awards', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
+                    [30605, 'Farming', 'BLANK', 'BLANK', 'BLANK', r'..\doc\case\file.doc', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_one(self):
@@ -161,15 +161,15 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30600', 'Casework Issues', 'nan', 'Casework', 'nan', 'nan', 'Casework'],
-                    ['30601', 'Health^Casework', 'Note', 'nan', 'nan', 'nan', 'Casework'],
-                    ['30603', 'Social Security', 'Open Case', 'nan', 'nan', 'nan', 'Casework']]
+                    [30600, 'Casework Issues', 'BLANK', 'Casework', 'BLANK', 'BLANK', 'Casework'],
+                    [30601, 'Health^Casework', 'Note', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Social Security', 'Open Case', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one category, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30604', 'Admin', 'nan', 'nan', 'For Casey', 'nan', 'Casework']]
+                    [30604, 'Admin', 'BLANK', 'BLANK', 'For Casey', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_none(self):
@@ -213,8 +213,8 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'out_document_name', 'Appraisal_Category'],
-                    ['30600', 'Casework^Academy Applicant', 'nan', 'nan', 'nan', 'nan', 'Academy_Application|Casework'],
-                    ['30601', 'Academy Applicant', 'Maybe casework', 'nan', 'rec for doe', 'nan',
+                    [30600, 'Casework^Academy Applicant', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application|Casework'],
+                    [30601, 'Academy Applicant', 'Maybe casework', 'BLANK', 'rec for doe', 'BLANK',
                      'Academy_Application|Casework|Recommendation']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
 

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -11,9 +11,9 @@ import unittest
 
 def csv_to_list(csv_path, sort=False):
     """Convert the contents of a CSV to a list which contains one list per row for easier comparison
-    with the option to sort for the match details report with inconsistent row order"""
-    df = pd.read_csv(csv_path, dtype=str)
-    df = df.fillna('nan')
+    with the option to sort for the report with inconsistent row order"""
+    df = pd.read_csv(csv_path)
+    df = df.fillna('BLANK')
     if sort:
         df = df.sort_values(by=['Category', 'Path'])
     csv_list = [df.columns.tolist()] + df.values.tolist()

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -83,15 +83,15 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['Ms.', 'Diane', 'D.', 'Dudly', 'nan', 'nan', 'nan', 'nan', '456 D St', 'nan', 'nan', 'nan',
-                     'D city', 'DE', '45678', 'nan', 'd100', 'General', 'Email', '20210101', 'Resumes',
-                     'nan', r'..\documents\BlobExport\objects\444444.txt', 'nan', 'r400', 'General', 'Email',
-                     '20210111', 'D', 'academy nomination', r'..\documents\BlobExport\indivletters\000004.txt', 'nan',
+                    ['Ms.', 'Diane', 'D.', 'Dudly', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '456 D St', 'BLANK', 'BLANK', 
+                     'BLANK', 'D city', 'DE', 45678, 'BLANK', 'd100', 'General', 'Email', 20210101, 'Resumes',
+                     'BLANK', r'..\documents\BlobExport\objects\444444.txt', 'BLANK', 'r400', 'General', 'Email',
+                     20210111, 'D', 'academy nomination', r'..\documents\BlobExport\indivletters\000004.txt', 'BLANK',
                      'Academy_Application|Job_Application'],
-                    ['Ms.', 'Emma', 'E.', 'Evans', 'nan', 'nan', 'nan', 'nan', '567 E St', 'nan', 'nan', 'nan',
-                     'E city', 'ME', '56789', 'nan', 'e100', 'General', 'Email', '20210101', 'Casework Issues',
-                     'nan', r'..\documents\BlobExport\objects\555555.txt', 'nan', 'r500', 'General', 'Email',
-                     '20210111', 'E', 'nan', r'..\documents\BlobExport\indivletters\000005.txt', 'nan', 'Casework']]
+                    ['Ms.', 'Emma', 'E.', 'Evans', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '567 E St', 'BLANK', 'BLANK', 
+                     'BLANK', 'E city', 'ME', 56789, 'BLANK', 'e100', 'General', 'Email', 20210101, 'Casework Issues',
+                     'BLANK', r'..\documents\BlobExport\objects\555555.txt', 'BLANK', 'r500', 'General', 'Email',
+                     20210111, 'E', 'BLANK', r'..\documents\BlobExport\indivletters\000005.txt', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for access, appraisal delete log")
 
         # Tests the contents of archiving_correspondence_redacted.csv.
@@ -100,14 +100,14 @@ class MyTestCase(unittest.TestCase):
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method', 'out_date',
                      'out_topic', 'out_document_name'],
-                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1',
-                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', '20210111',
+                    ['A city', 'AL', 12345, 'BLANK', 'a100', 'General', 'Email', 20210101, 'A1',
+                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', 20210111,
                      'A', r'..\documents\BlobExport\formletters\A'],
-                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2',
-                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', '20230212',
+                    ['B city', 'WY', 23456, 'BLANK', 'b200', 'General', 'Email', 20230202, 'B1^B2',
+                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', 20230212,
                      'B', r'..\documents\BlobExport\formletters\B'],
-                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1',
-                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', '20240313',
+                    ['C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'A1',
+                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', 20240313,
                      'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
 
@@ -117,8 +117,8 @@ class MyTestCase(unittest.TestCase):
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_document_name'],
-                    ['A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'A1',
-                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', '20210111',
+                    ['A city', 'AL', 12345, 'BLANK', 'a100', 'General', 'Email', 20210101, 'A1',
+                     r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', 20210111,
                      'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, 2021-2022.csv")
 
@@ -128,11 +128,11 @@ class MyTestCase(unittest.TestCase):
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_document_name'],
-                    ['B city', 'WY', '23456', 'nan', 'b200', 'General', 'Email', '20230202', 'B1^B2',
-                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', '20230212',
+                    ['B city', 'WY', 23456, 'BLANK', 'b200', 'General', 'Email', 20230202, 'B1^B2',
+                     r'..\documents\BlobExport\objects\222222.txt', 'r200', 'General', 'Email', 20230212,
                      'B', r'..\documents\BlobExport\formletters\B'],
-                    ['C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'A1',
-                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', '20240313',
+                    ['C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'A1',
+                     r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', 20240313,
                      'A', r'..\documents\BlobExport\formletters\A']]
         self.assertEqual(result, expected, "Problem with test for access, 2023-2024.csv")
 
@@ -182,10 +182,10 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['Ms.', 'Gretel', 'G.', 'Green', 'nan', 'nan', 'nan', 'nan', '789 G St', 'nan', 'nan', 'nan',
-                     'G city', 'GA', '78901', 'nan', 'g100', 'General', 'Email', '20210101', 'E', 'nan',
-                     r'..\documents\BlobExport\objects\777777.txt', 'nan', 'r700', 'General', 'Email', '20210111',
-                     'nan', 'nan', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
+                    ['Ms.', 'Gretel', 'G.', 'Green', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '789 G St', 'BLANK', 'BLANK', 
+                     'BLANK', 'G city', 'GA', 78901, 'BLANK', 'g100', 'General', 'Email', 20210101, 'E', 'BLANK',
+                     r'..\documents\BlobExport\objects\777777.txt', 'BLANK', 'r700', 'General', 'Email', 20210111,
+                     'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for accession, appraisal check log")
 
         # Tests the contents of the appraisal delete log.
@@ -195,30 +195,30 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'nan', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
-                     '345 C St', 'C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'Misc',
-                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'nan', 'r300', 'General',
-                     'Email', '2024-03-13', 'B1^B2', 'nan', r'..\documents\BlobExport\indivletters\000003.txt', 'nan',
-                     'Casework'],
-                    ['Ms.', 'Ann', 'A.', 'Anderson', 'nan', 'MD', 'nan', 'nan', '123 A St', 'nan', 'nan', 'nan',
-                     'A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'Misc',
-                     'academy nomination',
-                     r'..\documents\BlobExport\objects\111111.txt', 'nan', 'r100', 'General', 'Email', '20210111',
-                     'nan', 'nan', r'..\documents\BlobExport\indivletters\000001.txt', 'nan', 'Academy_Application'],
-                    ['Ms.', 'Diane', 'D.', 'Dudly', 'nan', 'nan', 'nan', 'nan', '456 D St', 'nan', 'nan', 'nan',
-                     'D city', 'DEL', '45678', 'nan', 'd100', 'General', 'Email', '20210101', 'Casework', 'nan',
-                     r'..\documents\BlobExport\objects\444444.txt', 'nan', 'r400', 'General', 'Email', '20210111',
-                     'Recommendations', 'nan', r'..\documents\BlobExport\formletters\D.txt', 'nan',
+                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'BLANK', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
+                     '345 C St', 'C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'Misc',
+                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'BLANK', 'r300', 'General',
+                     'Email', '2024-03-13', 'B1^B2', 'BLANK', r'..\documents\BlobExport\indivletters\000003.txt', 
+                     'BLANK', 'Casework'],
+                    ['Ms.', 'Ann', 'A.', 'Anderson', 'BLANK', 'MD', 'BLANK', 'BLANK', '123 A St', 'BLANK', 'BLANK', 
+                     'BLANK', 'A city', 'AL', 12345, 'BLANK', 'a100', 'General', 'Email', 20210101, 'Misc',
+                     'academy nomination', r'..\documents\BlobExport\objects\111111.txt', 'BLANK', 'r100', 'General', 
+                     'Email', '20210111', 'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000001.txt',
+                     'BLANK', 'Academy_Application'],
+                    ['Ms.', 'Diane', 'D.', 'Dudly', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '456 D St', 'BLANK', 'BLANK', 
+                     'BLANK', 'D city', 'DEL', 45678, 'BLANK', 'd100', 'General', 'Email', 20210101, 'Casework', 
+                     'BLANK', r'..\documents\BlobExport\objects\444444.txt', 'BLANK', 'r400', 'General', 'Email', 
+                     '20210111', 'Recommendations', 'BLANK', r'..\documents\BlobExport\formletters\D.txt', 'BLANK',
                      'Casework|Recommendation'],
-                    ['Ms.', 'Emma', 'E.', 'Evans', 'nan', 'nan', 'nan', 'nan', '567 E St', 'nan', 'nan', 'nan',
-                     'E city', 'ME', '56789', 'nan', 'e100', 'General', 'Email', '20210101', 'Recommendations', 'nan',
-                     r'..\documents\BlobExport\objects\555555.txt', 'nan', 'r500', 'General', 'Email', '20210111',
-                     'E', 'nan', r'..\documents\BlobExport\indivletters\000005.txt', 'nan', 'Recommendation'],
-                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'nan', 'nan', 'nan', 'nan', '678 F St', 'nan', 'nan', 'nan',
-                     'F city', 'fl', '67890', 'nan', 'f100', 'General', 'Email', '20210101',
-                     'Social Security^Casework', 'nan', 'nan', 'nan', 'r600',
-                     'General', 'Email', '20210111', 'E', 'nan', r'..\documents\BlobExport\formletters\F.txt', 'nan',
-                     'Casework']]
+                    ['Ms.', 'Emma', 'E.', 'Evans', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '567 E St', 'BLANK', 'BLANK', 
+                     'BLANK', 'E city', 'ME', 56789, 'BLANK', 'e100', 'General', 'Email', 20210101, 'Recommendations',
+                     'BLANK', r'..\documents\BlobExport\objects\555555.txt', 'BLANK', 'r500', 'General', 'Email', 
+                     '20210111', 'E', 'BLANK', r'..\documents\BlobExport\indivletters\000005.txt', 'BLANK',
+                     'Recommendation'],
+                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '678 F St', 'BLANK', 'BLANK', 
+                     'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
+                     'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', '20210111',
+                     'E', 'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for accession, appraisal delete log")
 
         # Tests the contents of metadata_formatting_errors_state.csv.
@@ -228,14 +228,14 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin'],
-                    ['Ms.', 'Diane', 'D.', 'Dudly', 'nan', 'nan', 'nan', 'nan', '456 D St', 'nan', 'nan', 'nan',
-                     'D city', 'DEL', '45678', 'nan', 'd100', 'General', 'Email', '20210101', 'Casework', 'nan',
-                     r'..\documents\BlobExport\objects\444444.txt', 'nan', 'r400', 'General', 'Email', '20210111',
-                     'Recommendations', 'nan', r'..\documents\BlobExport\formletters\D.txt', 'nan'],
-                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'nan', 'nan', 'nan', 'nan', '678 F St', 'nan', 'nan', 'nan',
-                     'F city', 'fl', '67890', 'nan', 'f100', 'General', 'Email', '20210101',
-                     'Social Security^Casework', 'nan', 'nan', 'nan', 'r600', 'General', 'Email', '20210111', 'E',
-                     'nan', r'..\documents\BlobExport\formletters\F.txt', 'nan']]
+                    ['Ms.', 'Diane', 'D.', 'Dudly', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '456 D St', 'BLANK', 'BLANK', 
+                     'BLANK', 'D city', 'DEL', 45678, 'BLANK', 'd100', 'General', 'Email', 20210101, 'Casework', 
+                     'BLANK', r'..\documents\BlobExport\objects\444444.txt', 'BLANK', 'r400', 'General', 'Email', 
+                     20210111, 'Recommendations', 'BLANK', r'..\documents\BlobExport\formletters\D.txt', 'BLANK'],
+                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '678 F St', 'BLANK', 'BLANK', 
+                     'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
+                     'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', 20210111, 'E',
+                     'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_state.csv")
 
         # Tests the contents of metadata_formatting_errors_out_date.csv.
@@ -245,10 +245,11 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin'],
-                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'nan', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
-                     '345 C St', 'C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'Misc',
-                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'nan', 'r300', 'General',
-                     'Email', '2024-03-13', 'B1^B2', 'nan', r'..\documents\BlobExport\indivletters\000003.txt', 'nan']]
+                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'BLANK', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
+                     '345 C St', 'C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'Misc',
+                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'BLANK', 'r300', 'General',
+                     'Email', '2024-03-13', 'B1^B2', 'BLANK', r'..\documents\BlobExport\indivletters\000003.txt', 
+                     'BLANK']]
         self.assertEqual(result, expected,
                          "Problem with test for accession, metadata_formatting_errors_out_date.csv")
 
@@ -265,23 +266,23 @@ class MyTestCase(unittest.TestCase):
         csv_path = os.path.join('test_data', 'script', 'topics_report.csv')
         result = csv_to_list(csv_path)
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
-                    ['B1^B2', '1', '2', '3'],
-                    ['BLANK', '0', '2', '2'],
-                    ['Casework', '1', '0', '1'],
-                    ['E', '1', '2', '3'],
-                    ['Misc', '2', '0', '2'],
-                    ['Recommendations', '1', '1', '2'],
-                    ['Social Security^Casework', '1', '0', '1']]
+                    ['B1^B2', 1, 2, 3],
+                    ['BLANK', 0, 2, 2],
+                    ['Casework', 1, 0, 1],
+                    ['E', 1, 2, 3],
+                    ['Misc', 2, 0, 2],
+                    ['Recommendations', 1, 1, 2],
+                    ['Social Security^Casework', 1, 0, 1]]
         self.assertEqual(result, expected, "Problem with test for accession, topics_report.csv")
 
         # Tests the contents of usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
         result = csv_to_list(csv_path)
         expected = [['Category', 'Count'],
-                    ['Metadata_Only', '3'],
-                    ['Directory_Only', '2'],
-                    ['Match', '10'],
-                    ['Metadata_Blank', '1']]
+                    ['Metadata_Only', 3],
+                    ['Directory_Only', 2],
+                    ['Match', 10],
+                    ['Metadata_Blank', 1]]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of usability_report_matching_details.csv.
@@ -299,38 +300,38 @@ class MyTestCase(unittest.TestCase):
         csv_path = os.path.join('test_data', 'script', 'usability_report_metadata.csv')
         result = csv_to_list(csv_path)
         expected = [['Column_Name', 'Present', 'Blank_Count', 'Blank_Percent', 'Formatting_Errors'],
-                    ['prefix', 'True', '0', '0.0', 'uncheckable'],
-                    ['first', 'True', '0', '0.0', 'uncheckable'],
-                    ['middle', 'True', '0', '0.0', 'uncheckable'],
-                    ['last', 'True', '0', '0.0', 'uncheckable'],
-                    ['suffix', 'True', '6', '85.71', 'uncheckable'],
-                    ['appellation', 'True', '6', '85.71', 'uncheckable'],
-                    ['title', 'True', '6', '85.71', 'uncheckable'],
-                    ['org', 'True', '6', '85.71', 'uncheckable'],
-                    ['addr1', 'True', '0', '0.0', 'uncheckable'],
-                    ['addr2', 'True', '5', '71.43', 'uncheckable'],
-                    ['addr3', 'True', '6', '85.71', 'uncheckable'],
-                    ['addr4', 'True', '6', '85.71', 'uncheckable'],
-                    ['city', 'True', '0', '0.0', 'uncheckable'],
-                    ['state', 'True', '0', '0.0', '2'],
-                    ['zip', 'True', '0', '0.0', '0'],
-                    ['country', 'True', '7', '100.0', 'uncheckable'],
-                    ['in_id', 'True', '0', '0.0', 'uncheckable'],
-                    ['in_type', 'True', '0', '0.0', 'uncheckable'],
-                    ['in_method', 'True', '0', '0.0', 'uncheckable'],
-                    ['in_date', 'True', '0', '0.0', '0'],
-                    ['in_topic', 'True', '0', '0.0', 'uncheckable'],
-                    ['in_text', 'True', '4', '57.14', 'uncheckable'],
-                    ['in_document_name', 'True', '1', '14.29', '0'],
-                    ['in_fillin', 'True', '7', '100.0', 'uncheckable'],
-                    ['out_id', 'True', '0', '0.0', 'uncheckable'],
-                    ['out_type', 'True', '0', '0.0', 'uncheckable'],
-                    ['out_method', 'True', '0', '0.0', 'uncheckable'],
-                    ['out_date', 'True', '0', '0.0', '1'],
-                    ['out_topic', 'True', '2', '28.57', 'uncheckable'],
-                    ['out_text', 'True', '7', '100.0', 'uncheckable'],
-                    ['out_document_name', 'True', '0', '0.0', '0'],
-                    ['out_fillin', 'True', '6', '85.71', 'uncheckable']]
+                    ['prefix', True, 0, 0.0, 'uncheckable'],
+                    ['first', True, 0, 0.0, 'uncheckable'],
+                    ['middle', True, 0, 0.0, 'uncheckable'],
+                    ['last', True, 0, 0.0, 'uncheckable'],
+                    ['suffix', True, 6, 85.71, 'uncheckable'],
+                    ['appellation', True, 6, 85.71, 'uncheckable'],
+                    ['title', True, 6, 85.71, 'uncheckable'],
+                    ['org', True, 6, 85.71, 'uncheckable'],
+                    ['addr1', True, 0, 0.0, 'uncheckable'],
+                    ['addr2', True, 5, 71.43, 'uncheckable'],
+                    ['addr3', True, 6, 85.71, 'uncheckable'],
+                    ['addr4', True, 6, 85.71, 'uncheckable'],
+                    ['city', True, 0, 0.0, 'uncheckable'],
+                    ['state', True, 0, 0.0, '2'],
+                    ['zip', True, 0, 0.0, '0'],
+                    ['country', True, 7, 100.0, 'uncheckable'],
+                    ['in_id', True, 0, 0.0, 'uncheckable'],
+                    ['in_type', True, 0, 0.0, 'uncheckable'],
+                    ['in_method', True, 0, 0.0, 'uncheckable'],
+                    ['in_date', True, 0, 0.0, '0'],
+                    ['in_topic', True, 0, 0.0, 'uncheckable'],
+                    ['in_text', True, 4, 57.14, 'uncheckable'],
+                    ['in_document_name', True, 1, 14.29, '0'],
+                    ['in_fillin', True, 7, 100.0, 'uncheckable'],
+                    ['out_id', True, 0, 0.0, 'uncheckable'],
+                    ['out_type', True, 0, 0.0, 'uncheckable'],
+                    ['out_method', True, 0, 0.0, 'uncheckable'],
+                    ['out_date', True, 0, 0.0, '1'],
+                    ['out_topic', True, 2, 28.57, 'uncheckable'],
+                    ['out_text', True, 7, 100.0, 'uncheckable'],
+                    ['out_document_name', True, 0, 0.0, '0'],
+                    ['out_fillin', True, 6, 85.71, 'uncheckable']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_metadata.csv")
 
         # Tests the other script mode outputs were not made.
@@ -368,10 +369,10 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['Ms.', 'Gretel', 'G.', 'Green', 'nan', 'nan', 'nan', 'nan', '789 G St', 'nan', 'nan', 'nan',
-                     'G city', 'GA', '78901', 'nan', 'g100', 'General', 'Email', '20210101', 'E', 'nan',
-                     r'..\documents\BlobExport\objects\777777.txt', 'nan', 'r700', 'General', 'Email', '20210111',
-                     'nan', 'nan', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
+                    ['Ms.', 'Gretel', 'G.', 'Green', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '789 G St', 'BLANK', 'BLANK',
+                     'BLANK', 'G city', 'GA', 78901, 'BLANK', 'g100', 'General', 'Email', 20210101, 'E', 'BLANK',
+                     r'..\documents\BlobExport\objects\777777.txt', 'BLANK', 'r700', 'General', 'Email', 20210111,
+                     'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for appraisal, appraisal check log")
 
         # Tests the contents of the appraisal delete log.
@@ -381,30 +382,30 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'nan', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
-                     '345 C St', 'C city', 'CO', '34567', 'nan', 'c300', 'General', 'Letter', '20240303', 'Misc',
-                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'nan', 'r300', 'General',
-                     'Email', '2024-03-13', 'B1^B2', 'nan', r'..\documents\BlobExport\indivletters\000003.txt', 'nan',
-                     'Casework'],
-                    ['Ms.', 'Ann', 'A.', 'Anderson', 'nan', 'MD', 'nan', 'nan', '123 A St', 'nan', 'nan', 'nan',
-                     'A city', 'AL', '12345', 'nan', 'a100', 'General', 'Email', '20210101', 'Misc',
-                     'academy nomination',
-                     r'..\documents\BlobExport\objects\111111.txt', 'nan', 'r100', 'General', 'Email', '20210111',
-                     'nan', 'nan', r'..\documents\BlobExport\indivletters\000001.txt', 'nan', 'Academy_Application'],
-                    ['Ms.', 'Diane', 'D.', 'Dudly', 'nan', 'nan', 'nan', 'nan', '456 D St', 'nan', 'nan', 'nan',
-                     'D city', 'DEL', '45678', 'nan', 'd100', 'General', 'Email', '20210101', 'Casework', 'nan',
-                     r'..\documents\BlobExport\objects\444444.txt', 'nan', 'r400', 'General', 'Email', '20210111',
-                     'Recommendations', 'nan', r'..\documents\BlobExport\formletters\D.txt', 'nan',
+                    ['Mr.', 'Clive', 'C.', 'Cooper', 'Jr.', 'BLANK', 'CEO', 'Company', 'Attn: C', 'Division', 'POBox',
+                     '345 C St', 'C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'Misc',
+                     'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'BLANK', 'r300', 'General',
+                     'Email', '2024-03-13', 'B1^B2', 'BLANK', r'..\documents\BlobExport\indivletters\000003.txt',
+                     'BLANK', 'Casework'],
+                    ['Ms.', 'Ann', 'A.', 'Anderson', 'BLANK', 'MD', 'BLANK', 'BLANK', '123 A St', 'BLANK', 'BLANK',
+                     'BLANK', 'A city', 'AL', 12345, 'BLANK', 'a100', 'General', 'Email', 20210101, 'Misc',
+                     'academy nomination', r'..\documents\BlobExport\objects\111111.txt', 'BLANK', 'r100', 'General',
+                     'Email', '20210111', 'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000001.txt',
+                     'BLANK', 'Academy_Application'],
+                    ['Ms.', 'Diane', 'D.', 'Dudly', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '456 D St', 'BLANK', 'BLANK',
+                     'BLANK', 'D city', 'DEL', 45678, 'BLANK', 'd100', 'General', 'Email', 20210101, 'Casework',
+                     'BLANK', r'..\documents\BlobExport\objects\444444.txt', 'BLANK', 'r400', 'General', 'Email',
+                     '20210111', 'Recommendations', 'BLANK', r'..\documents\BlobExport\formletters\D.txt', 'BLANK',
                      'Casework|Recommendation'],
-                    ['Ms.', 'Emma', 'E.', 'Evans', 'nan', 'nan', 'nan', 'nan', '567 E St', 'nan', 'nan', 'nan',
-                     'E city', 'ME', '56789', 'nan', 'e100', 'General', 'Email', '20210101', 'Recommendations', 'nan',
-                     r'..\documents\BlobExport\objects\555555.txt', 'nan', 'r500', 'General', 'Email', '20210111',
-                     'E', 'nan', r'..\documents\BlobExport\indivletters\000005.txt', 'nan', 'Recommendation'],
-                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'nan', 'nan', 'nan', 'nan', '678 F St', 'nan', 'nan', 'nan',
-                     'F city', 'fl', '67890', 'nan', 'f100', 'General', 'Email', '20210101',
-                     'Social Security^Casework', 'nan', 'nan', 'nan', 'r600',
-                     'General', 'Email', '20210111', 'E', 'nan', r'..\documents\BlobExport\formletters\F.txt', 'nan',
-                     'Casework']]
+                    ['Ms.', 'Emma', 'E.', 'Evans', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '567 E St', 'BLANK', 'BLANK',
+                     'BLANK', 'E city', 'ME', 56789, 'BLANK', 'e100', 'General', 'Email', 20210101, 'Recommendations',
+                     'BLANK', r'..\documents\BlobExport\objects\555555.txt', 'BLANK', 'r500', 'General', 'Email',
+                     '20210111', 'E', 'BLANK', r'..\documents\BlobExport\indivletters\000005.txt', 'BLANK',
+                     'Recommendation'],
+                    ['Ms.', 'Fiona', 'F.', 'Fowler', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '678 F St', 'BLANK', 'BLANK',
+                     'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
+                     'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', '20210111',
+                     'E', 'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for appraisal, appraisal delete log")
 
         # Tests the contents of the file deletion log.
@@ -413,19 +414,19 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(csv_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'..\documents\objects\333333.txt'.replace('..', input_directory),
-                     '0.8', today, today, '09F83C9A1604F2DBCB8471DACCB99A49', 'Casework'],
+                     0.8, today, today, '09F83C9A1604F2DBCB8471DACCB99A49', 'Casework'],
                     [r'..\documents\indivletters\000003.txt'.replace('..', input_directory),
-                     '3.5', today, today, '3E273CCDD4D24DBFCD55B519999BABC7', 'Casework'],
+                     3.5, today, today, '3E273CCDD4D24DBFCD55B519999BABC7', 'Casework'],
                     [r'..\documents\objects\111111.txt'.replace('..', input_directory),
-                     '0.0', today, today, 'C53D3BB354B533DE159BB7C89E0433D5', 'Academy_Application'],
+                     0.0, today, today, 'C53D3BB354B533DE159BB7C89E0433D5', 'Academy_Application'],
                     [r'..\documents\indivletters\000001.txt'.replace('..', input_directory),
-                     '0.1', today, today, '21E65C7B733959A8B3E6071EB0748BF6', 'Academy_Application'],
+                     0.1, today, today, '21E65C7B733959A8B3E6071EB0748BF6', 'Academy_Application'],
                     [r'..\documents\objects\444444.txt'.replace('..', input_directory),
-                     'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError'],
+                     'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\objects\555555.txt'.replace('..', input_directory),
-                     'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError'],
+                     'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\indivletters\000005.txt'.replace('..', input_directory),
-                     '1.2', today, today, 'EFBB58E35027F2382E2C58F22B895B7C', 'Recommendation']]
+                     1.2, today, today, 'EFBB58E35027F2382E2C58F22B895B7C', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for appraisal, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.

--- a/tests/css_archiving_format/test_split_congress_year.py
+++ b/tests/css_archiving_format/test_split_congress_year.py
@@ -37,23 +37,23 @@ class MyTestCase(unittest.TestCase):
         # Tests that 1981-1982.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1981-1982.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30603', '19810505', 'oranges', '19810509', 'fruit'],
-                    ['30603', '19820505', 'oranges', '19820509', 'fruit']]
+                    [30603, 19810505, 'oranges', 19810509, 'fruit'],
+                    [30603, 19820505, 'oranges', 19820509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for all years, 1981-1982")
 
         # Tests that 1987-1988.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1987-1988.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30601', '19870104', 'cats', 'nan', 'pets'],
-                    ['30601', '19881001', 'dogs', '19881005', 'nan'],
-                    ['30602', '19881202', 'cats', '19890105', 'pets']]
+                    [30601, 19870104, 'cats', 'BLANK', 'pets'],
+                    [30601, 19881001, 'dogs', 19881005, 'BLANK'],
+                    [30602, 19881202, 'cats', 19890105, 'pets']]
         self.assertEqual(result, expected, "Problem with test for all years, 1987-1988")
 
         # Tests that undated.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30602', 'nan', 'cats', '19890105', 'pets'],
-                    ['30603', 'date_error', 'oranges', '19820509', 'fruit']]
+                    [30602, 'BLANK', 'cats', 19890105, 'pets'],
+                    [30603, 'date_error', 'oranges', 19820509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for all years, 1987-1988")
 
     def test_date_blank(self):
@@ -67,8 +67,8 @@ class MyTestCase(unittest.TestCase):
         # Tests that undated has the correct values.
         result = csv_to_list(os.path.join('test_data', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30601', 'nan', 'dogs', 'nan', 'pets'],
-                    ['30602', 'nan', 'cats', 'nan', 'pets']]
+                    [30601, 'BLANK', 'dogs', 'BLANK', 'pets'],
+                    [30602, 'BLANK', 'cats', 'BLANK', 'pets']]
         self.assertEqual(result, expected, "Problem with test for date blank, undated")
 
     def test_date_text(self):
@@ -82,8 +82,8 @@ class MyTestCase(unittest.TestCase):
         # Tests that undated has the correct values.
         result = csv_to_list(os.path.join('test_data', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30601', 'error', 'cats', '19950105', 'pets'],
-                    ['30601', 'error_date', 'dogs', '19950105', 'pets']]
+                    [30601, 'error', 'cats', 19950105, 'pets'],
+                    [30601, 'error_date', 'dogs', 19950105, 'pets']]
         self.assertEqual(result, expected, "Problem with test for date text, undated")
 
     def test_even_years(self):
@@ -99,15 +99,15 @@ class MyTestCase(unittest.TestCase):
         # Tests that 1989-1990.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1989-1990.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30601', '19900104', 'cats', '19900105', 'pets'],
-                    ['30601', '19901001', 'dogs', '19901005', 'pets'],
-                    ['30602', '19901202', 'cats', '19910105', 'pets']]
+                    [30601, 19900104, 'cats', 19900105, 'pets'],
+                    [30601, 19901001, 'dogs', 19901005, 'pets'],
+                    [30602, 19901202, 'cats', 19910105, 'pets']]
         self.assertEqual(result, expected, "Problem with test for even years, 1989-1990")
 
         # Tests that 2001-2002.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '2001-2002.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30603', '20020505', 'oranges', '20020509', 'fruit']]
+                    [30603, 20020505, 'oranges', 20020509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for even years, 2001-2002")
 
     def test_odd_years(self):
@@ -123,15 +123,15 @@ class MyTestCase(unittest.TestCase):
         # Tests that 1997-1998.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1997-1998.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30601', '19970104', 'cats', '19970105', 'pets'],
-                    ['30601', '19971001', 'dogs', '19971005', 'pets'],
-                    ['30602', '19971202', 'cats', '19980105', 'pets']]
+                    [30601, 19970104, 'cats', 19970105, 'pets'],
+                    [30601, 19971001, 'dogs', 19971005, 'pets'],
+                    [30602, 19971202, 'cats', 19980105, 'pets']]
         self.assertEqual(result, expected, "Problem with test for odd years, 1997-1998")
 
         # Tests that 2009-2010.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '2009-2010.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
-                    ['30603', '20090505', 'oranges', '20090509', 'fruit']]
+                    [30603, 20090505, 'oranges', 20090509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for even years, 2009-2010")
 
 

--- a/tests/css_archiving_format/test_topics_report.py
+++ b/tests/css_archiving_format/test_topics_report.py
@@ -36,14 +36,14 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
-                    ['BLANK', '2', '0', '2'],
-                    ['Baseball', '1', '0', '1'],
-                    ['Chess', '1', '1', '2'],
-                    ['Food', '0', '1', '1'],
-                    ['Pets', '0', '2', '2'],
-                    ['Puppies', '2', '0', '2'],
-                    ['Sports', '0', '3', '3'],
-                    ['Water', '3', '2', '5']]
+                    ['BLANK', 2, 0, 2],
+                    ['Baseball', 1, 0, 1],
+                    ['Chess', 1, 1, 2],
+                    ['Food', 0, 1, 1],
+                    ['Pets', 0, 2, 2],
+                    ['Puppies', 2, 0, 2],
+                    ['Sports', 0, 3, 3],
+                    ['Water', 3, 2, 5]]
         self.assertEqual(result, expected, "Problem with test for all")
 
     def test_blanks(self):
@@ -59,8 +59,8 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
-                    ['BLANK', '3', '2', '5'],
-                    ['Water', '1', '2', '3']]
+                    ['BLANK', 3, 2, 5],
+                    ['Water', 1, 2, 3]]
         self.assertEqual(result, expected, "Problem with test for blanks")
 
     def test_shared(self):
@@ -80,11 +80,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
-                    ['Baseball', '1', '1', '2'],
-                    ['Pets', '1', '3', '4'],
-                    ['Puppies', '3', '1', '4'],
-                    ['Sports', '1', '1', '2'],
-                    ['Water', '2', '2', '4']]
+                    ['Baseball', 1, 1, 2],
+                    ['Pets', 1, 3, 4],
+                    ['Puppies', 3, 1, 4],
+                    ['Sports', 1, 1, 2],
+                    ['Water', 2, 2, 4]]
         self.assertEqual(result, expected, "Problem with test for shared")
 
     def test_unique(self):
@@ -99,10 +99,10 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
-                    ['Chess', '1', '0', '1'],
-                    ['Ecology', '0', '1', '1'],
-                    ['Sports', '0', '2', '2'],
-                    ['Water', '2', '0', '2']]
+                    ['Chess', 1, 0, 1],
+                    ['Ecology', 0, 1, 1],
+                    ['Sports', 0, 2, 2],
+                    ['Water', 2, 0, 2]]
         self.assertEqual(result, expected, "Problem with test for unique")
 
 


### PR DESCRIPTION
Use one csv_to_list() function for all unit tests. Read without specifying dtype, fill na with "BLANK", and have an option to sort for a report that has inconsistent row order.