### PR TITLE
Check arg error tests

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -46,6 +46,10 @@ def check_arguments(arg_list):
         else:
             errors.append(f"Provided input_directory '{arg_list[1]}' does not exist")
 
+    # Only one required argument is present.
+    if len(arg_list) == 2:
+        errors.append("Missing one of the required arguments, input_directory or script_mode")
+
     # Both required arguments are present.
     # Verifies the second is one of the expected modes.
     if len(arg_list) > 2:

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -93,20 +93,20 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, None, "Problem with error - missing two, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error - missing two, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
+    def test_error_mode(self):
+        """Test for when the mode argument is not an expected value."""
         # Runs the function being tested.
         input_dir = os.path.join('test_data', 'check_arguments', 'correct')
-        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        sys_argv = ['css_archiving_format.py', input_dir, 'unexpected']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        expected_errors = ["Provided mode 'unexpected' is not one of the expected modes"]
+        self.assertEqual(input_directory, input_dir, "Problem with error - mode, input_directory")
         self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+                         "Problem with error - mode, metadata_path")
+        self.assertEqual(script_mode, None, "Problem with error - mode, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - mode, errors_list")
 
     def test_error_x(self):
         """Test for when ."""

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -73,7 +73,7 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
+        expected_errors = ["Missing one of the required arguments, input_directory or script_mode"]
         self.assertEqual(input_directory, input_dir, "Problem with error - missing one, input_directory")
         self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
                          "Problem with error - missing one, metadata_path")

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -108,20 +108,19 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, None, "Problem with error - mode, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error - mode, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
+    def test_error_path_dat(self):
+        """Test for when input_directory contains no archiving correspondence dat file."""
         # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        input_dir = os.path.join('test_data', 'check_arguments', 'no_dat')
         sys_argv = ['css_archiving_format.py', input_dir, 'access']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+        expected_errors = ["No archiving_correspondence.dat file in the input_directory"]
+        self.assertEqual(input_directory, input_dir, "Problem with error - path dat, input_directory")
+        self.assertEqual(metadata_path, None, "Problem with error - path dat, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - path dat, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - path dat, errors_list")
 
     def test_error_x(self):
         """Test for when ."""

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -151,6 +151,22 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'access', "Problem with error - too many arg, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error - too many arg, errors_list")
 
+    def test_errors(self):
+        """Test for multiple errors."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'missing')
+        sys_argv = ['css_archiving_format.py', input_dir, 'error', 'bonus']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = [f"Provided input_directory '{input_dir}' does not exist",
+                           "Provided mode 'error' is not one of the expected modes",
+                           "Provided more than the required arguments, input_directory and script_mode"]
+        self.assertEqual(input_directory, None, "Problem with errors, input_directory")
+        self.assertEqual(metadata_path, None, "Problem with errors, metadata_path")
+        self.assertEqual(script_mode, None, "Problem with errors, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with errors, errors_list")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -65,6 +65,96 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
         self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
 
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+    def test_error_x(self):
+        """Test for when ."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - x, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -65,6 +65,21 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
         self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
 
+    def test_error_missing_one(self):
+        """Test for when one required argument (mode) is missing."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['css_archiving_format.py', input_dir]
+        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_errors = []
+        self.assertEqual(input_directory, input_dir, "Problem with error - missing one, input_directory")
+        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+                         "Problem with error - missing one, metadata_path")
+        self.assertEqual(script_mode, None, "Problem with error - missing one, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - missing one, errors_list")
+
     def test_error_x(self):
         """Test for when ."""
         # Runs the function being tested.
@@ -140,21 +155,6 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
-        # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
-        sys_argv = ['css_archiving_format.py', input_dir, 'access']
-        input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
-        # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
-
-        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -80,20 +80,18 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, None, "Problem with error - missing one, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error - missing one, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
+    def test_error_missing_two(self):
+        """Test for when both required arguments are missing."""
         # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
-        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        sys_argv = ['css_archiving_format.py']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+        expected_errors = ["Missing required arguments, input_directory and script_mode"]
+        self.assertEqual(input_directory, None, "Problem with error - missing two, input_directory")
+        self.assertEqual(metadata_path, None, "Problem with error - missing two, metadata_path")
+        self.assertEqual(script_mode, None, "Problem with error - missing two, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - missing two, errors_list")
 
     def test_error_x(self):
         """Test for when ."""

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -122,35 +122,34 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'access', "Problem with error - path dat, script_mode")
         self.assertEqual(errors_list, expected_errors, "Problem with error - path dat, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
+    def test_error_path_invalid(self):
+        """Test for when input_directory is a path that does not exist."""
         # Runs the function being tested.
-        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        input_dir = os.path.join('test_data', 'check_arguments', 'error')
         sys_argv = ['css_archiving_format.py', input_dir, 'access']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+        expected_errors = [f"Provided input_directory '{input_dir}' does not exist"]
+        self.assertEqual(input_directory, None, "Problem with error - path invalid, input_directory")
+        self.assertEqual(metadata_path, None, "Problem with error - path invalid, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - path invalid, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - path invalid, errors_list")
 
-    def test_error_x(self):
-        """Test for when ."""
+    def test_error_too_many_arg(self):
+        """Test for when more than the required two arguments are provided."""
         # Runs the function being tested.
         input_dir = os.path.join('test_data', 'check_arguments', 'correct')
-        sys_argv = ['css_archiving_format.py', input_dir, 'access']
+        sys_argv = ['css_archiving_format.py', input_dir, 'access', 'extra', 'extra2']
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        expected_errors = []
-        self.assertEqual(input_directory, input_dir, "Problem with error - x, input_directory")
+        expected_errors = ["Provided more than the required arguments, input_directory and script_mode"]
+        self.assertEqual(input_directory, input_dir, "Problem with error - too many arg, input_directory")
         self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
-                         "Problem with error - x, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - x, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error-x, errors_list")
+                         "Problem with error - too many arg, metadata_path")
+        self.assertEqual(script_mode, 'access', "Problem with error - too many arg, script_mode")
+        self.assertEqual(errors_list, expected_errors, "Problem with error - too many arg, errors_list")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_data/check_arguments/no_dat/metadata.txt
+++ b/tests/css_archiving_format/test_data/check_arguments/no_dat/metadata.txt
@@ -1,0 +1,1 @@
+Placeholder for check_arguments() test that needs a valid folder directory without a DAT file.


### PR DESCRIPTION
Add unit tests for potential errors to test_check_arguments, and add an error message for when there is only one provided argument (two are required).