### PR TITLE
CSS ARCH path emailobj

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -580,15 +580,18 @@ def topics_report(df, output_dir):
 def update_path(md_path, input_dir):
     """Update a path found in the metadata to match the actual directory structure of the exports"""
 
-    # So far, we have seen two ways that paths are formatted in the metadata:
-    # ..\documents\BlobExport\folder\..\file.ext, where the export is \documents\folder\..\file.ext AND
+    # So far, we have seen three ways that paths are formatted in the metadata:
+    # ..\documents\BlobExport\folder\..\file.ext, where the export is \documents\folder\..\file.ext
     #  \\name-office\dos\public\folder\..\file.ext, where the export is \documents\folder\..\file.ext
+    # e:\emailobj\folder\file.ext, where export pattern is unknown (none in export)
     if md_path.startswith('..'):
         updated_path = md_path.replace('..', input_dir)
         updated_path = updated_path.replace('\\BlobExport', '')
     elif '\\dos\\public\\' in md_path:
         updated_path = re.sub('\\\\[a-z]+-[a-z]+\\\\dos\\\\public', 'documents', md_path)
         updated_path = input_dir + updated_path
+    elif md_path.startswith('e:\\emailobj\\'):
+        updated_path = md_path.replace('e:', input_dir)
     else:
         updated_path = 'error_new'
 

--- a/tests/css_archiving_format/test_update_path.py
+++ b/tests/css_archiving_format/test_update_path.py
@@ -19,6 +19,12 @@ class MyTestCase(unittest.TestCase):
         expected = r'input_dir\documents\letter\111111.txt'
         self.assertEqual(file_path, expected, "Problem with test for Dos")
 
+    def test_emailobj(self):
+        """Test for the pattern e:\\emailobj\\folder\\file.ext"""
+        file_path = update_path(r'e:\emailobj\202112\12345678.txt', 'input_dir')
+        expected = r'input_dir\emailobj\202112\12345678.txt'
+        self.assertEqual(file_path, expected, "Problem with test for emailobj")
+
     def test_new(self):
         """Test for a new pattern"""
         file_path = update_path(r'\folder\folder\letter\111111.txt', 'input_dir')


### PR DESCRIPTION
Add a third path option, e:\emailobj\folder\file.txt, to update_path. The resulting path is input_dir\emailobj\folder\file.txt.