### PR TITLE
CSS_ARCH appraisal casework

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -365,6 +365,12 @@ def find_casework_rows(df):
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
+    # Column out_text is equal to a keyword that indicates casework.
+    keyword_list = ['case', 'case!']
+    out_text = df['out_text'].str.lower().isin(keyword_list)
+    df_out_text = df[out_text]
+    df = df[~out_text]
+
     # Any column includes a phrase that indicates casework.
     case_list = ['added to case', 'already open', 'case closed', 'case for', 'case has been opened', 'case issue',
                  'case work', 'casew', 'closed case', 'open case', 'started case']
@@ -374,7 +380,7 @@ def find_casework_rows(df):
 
     # Makes a single dataframe with all rows that indicate casework
     # and adds a column for the appraisal category (needed for the file deletion log).
-    df_casework = pd.concat([df_in_topic, df_out_topic, df_phrase], axis=0, ignore_index=True)
+    df_casework = pd.concat([df_in_topic, df_out_topic, df_out_text, df_phrase], axis=0, ignore_index=True)
     df_casework['Appraisal_Category'] = "Casework"
 
     # Makes another dataframe with any remaining rows with "case" in any column

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -366,7 +366,8 @@ def find_casework_rows(df):
     df = df[~out_topic]
 
     # Any column includes a phrase that indicates casework.
-    case_list = ['added to case', 'already open', 'closed case', 'casework', 'open case', 'started case']
+    case_list = ['added to case', 'already open', 'case closed', 'case for', 'case has been opened', 'case issue',
+                 'case work', 'casework', 'closed case', 'open case', 'started case']
     case_phrase = np.column_stack([df[col].str.contains('|'.join(case_list), case=False, na=False) for col in df])
     df_phrase = df.loc[case_phrase.any(axis=1)]
     df = df.loc[~case_phrase.any(axis=1)]

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -367,7 +367,7 @@ def find_casework_rows(df):
 
     # Any column includes a phrase that indicates casework.
     case_list = ['added to case', 'already open', 'case closed', 'case for', 'case has been opened', 'case issue',
-                 'case work', 'casework', 'closed case', 'open case', 'started case']
+                 'case work', 'casew', 'closed case', 'open case', 'started case']
     case_phrase = np.column_stack([df[col].str.contains('|'.join(case_list), case=False, na=False) for col in df])
     df_phrase = df.loc[case_phrase.any(axis=1)]
     df = df.loc[~case_phrase.any(axis=1)]

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -365,22 +365,15 @@ def find_casework_rows(df):
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
-    # Any column includes the text "casework".
-    # This includes a few rows with phrases like "this is not casework",
-    # which is necessary to protect privacy and keep time required reasonable.
-    casework = np.column_stack([df[col].str.contains('casework', case=False, na=False) for col in df])
-    df_cw = df.loc[casework.any(axis=1)]
-    df = df.loc[~casework.any(axis=1)]
-
     # Any column includes a phrase that indicates casework.
-    case_list = ['added to case', 'already open', 'closed case', 'open case', 'started case']
+    case_list = ['added to case', 'already open', 'closed case', 'casework', 'open case', 'started case']
     case_phrase = np.column_stack([df[col].str.contains('|'.join(case_list), case=False, na=False) for col in df])
     df_phrase = df.loc[case_phrase.any(axis=1)]
     df = df.loc[~case_phrase.any(axis=1)]
 
     # Makes a single dataframe with all rows that indicate casework
     # and adds a column for the appraisal category (needed for the file deletion log).
-    df_casework = pd.concat([df_in_topic, df_out_topic, df_cw, df_phrase], axis=0, ignore_index=True)
+    df_casework = pd.concat([df_in_topic, df_out_topic, df_phrase], axis=0, ignore_index=True)
     df_casework['Appraisal_Category'] = "Casework"
 
     # Makes another dataframe with any remaining rows with "case" in any column

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -20,12 +20,12 @@ class MyTestCase(unittest.TestCase):
                               ['30603', 'Health', 'open case', ''],
                               ['30604', '', 'Started case Wed', 'Admin'],
                               ['30605', 'Prison Case', '', 'Casework']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30600', 'Casework Issues', 'note', 'Issues', 'Casework'],
                     ['30605', 'Prison Case', '', 'Casework', 'Casework'],
                     ['30602', 'Health', 'This is casework', 'Casework^Medical', 'Casework'],
@@ -36,7 +36,7 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for all casework, df_casework_check")
 
     def test_in_topic(self):
@@ -51,12 +51,12 @@ class MyTestCase(unittest.TestCase):
                               ['30606', 'Prison Case^No Reply', '', 'Justice'],
                               ['30607', 'Keep', 'CASE OF THE CENTURY', 'Legal'],
                               ['30608', 'Casework^Casework Issues', '', 'Admin']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30600', 'Casework', '', 'Admin', 'Casework'],
                     ['30602', 'Casework Issues', '', 'Admin', 'Casework'],
                     ['30603', 'Prison Case', 'note', 'Justice', 'Casework'],
@@ -68,7 +68,7 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30607', 'Keep', 'CASE OF THE CENTURY', 'Legal', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_casework_check")
 
@@ -77,18 +77,46 @@ class MyTestCase(unittest.TestCase):
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Keep', '', 'Keep'],
                               ['30601', 'Healthcare', '', 'Healthcare']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework_check")
+
+    def test_out_text(self):
+        """Test for when the column out_text is equal to a keyword that indicates casework"""
+        # Makes a dataframe to use as test input and runs the function.
+        md_df = pd.DataFrame([['30601', '', 'Case!', ''],
+                              ['30602', 'Admin', 'CASE', ''],
+                              ['30603', '', 'Not case', ''],
+                              ['30604', '', 'case!', ''],
+                              ['30605', '', 'Just in case', 'Admin'],
+                              ['30606', '', 'case', '']],
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        df_casework, df_casework_check = find_casework_rows(md_df)
+
+        # Tests the values in df_casework are correct.
+        result = df_to_list(df_casework)
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
+                    ['30601', '', 'Case!', '', 'Casework'],
+                    ['30602', 'Admin', 'CASE', '', 'Casework'],
+                    ['30604', '', 'case!', '', 'Casework'],
+                    ['30606', '', 'case', '', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for out_text, df_casework")
+
+        # Tests the values in df_casework_check are correct.
+        result = df_to_list(df_casework_check)
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
+                    ['30603', '', 'Not case', '', 'Casework'],
+                    ['30605', '', 'Just in case', 'Admin', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for out_text, df_casework_check")
 
     def test_out_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
@@ -99,12 +127,12 @@ class MyTestCase(unittest.TestCase):
                               ['30603', '', '', 'Prison Case'],
                               ['30604', '', '', 'Casework^Casework Issues'],
                               ['30605', 'Admin', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30600', 'Admin', '', 'Casework', 'Casework'],
                     ['30601', 'Admin', '', 'Healthcare^Casework', 'Casework'],
                     ['30602', 'SSA', 'note', 'Casework Issues^Social Security', 'Casework'],
@@ -114,7 +142,7 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_casework_check")
 
     def test_phase(self):
@@ -133,12 +161,12 @@ class MyTestCase(unittest.TestCase):
                               ['30609', 'Open Case', '', ''],
                               ['30610', '', 'Mary started case yesterday', 'Admin'],
                               ['30611', 'Roads', 'Not a case', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
+                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30600', '', 'I added to case', '', 'Casework'],
                     ['30601', '', 'Already opened a case', '', 'Casework'],
                     ['30602', '', 'CASE CLOSED', '', 'Casework'],
@@ -155,7 +183,7 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
+        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
                     ['30611', 'Roads', 'Not a case', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework_check")
 

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -122,11 +122,16 @@ class MyTestCase(unittest.TestCase):
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', '', 'I added to case', ''],
                               ['30601', '', 'Already opened a case', ''],
-                              ['30602', 'Closed Case', '', ''],
-                              ['30603', 'Open Case', '', ''],
-                              ['30604', '', 'For casework', ''],
-                              ['30605', '', 'Mary started case yesterday', 'Admin'],
-                              ['30606', 'Roads', 'Not a case', '']],
+                              ['30602', '', 'CASE CLOSED', ''],
+                              ['30603', '', 'Case for doe', ''],
+                              ['30604', '', 'A case has been opened', ''],
+                              ['30605', '', 'Maybe case issue', ''],
+                              ['30606', '', 'case work', ''],
+                              ['30607', '', 'For casework', ''],
+                              ['30608', 'Closed Case', '', ''],
+                              ['30609', 'Open Case', '', ''],
+                              ['30610', '', 'Mary started case yesterday', 'Admin'],
+                              ['30611', 'Roads', 'Not a case', '']],
                              columns=['zip', 'in_topic', 'in_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
@@ -135,16 +140,21 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
                     ['30600', '', 'I added to case', '', 'Casework'],
                     ['30601', '', 'Already opened a case', '', 'Casework'],
-                    ['30602', 'Closed Case', '', '', 'Casework'],
-                    ['30603', 'Open Case', '', '', 'Casework'],
-                    ['30604', '', 'For casework', '', 'Casework'],
-                    ['30605', '', 'Mary started case yesterday', 'Admin', 'Casework']]
+                    ['30602', '', 'CASE CLOSED', '', 'Casework'],
+                    ['30603', '', 'Case for doe', '', 'Casework'],
+                    ['30604', '', 'A case has been opened', '', 'Casework'],
+                    ['30605', '', 'Maybe case issue', '', 'Casework'],
+                    ['30606', '', 'case work', '', 'Casework'],
+                    ['30607', '', 'For casework', '', 'Casework'],
+                    ['30608', 'Closed Case', '', '', 'Casework'],
+                    ['30609', 'Open Case', '', '', 'Casework'],
+                    ['30610', '', 'Mary started case yesterday', 'Admin', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
-                    ['30606', 'Roads', 'Not a case', '', 'Casework']]
+                    ['30611', 'Roads', 'Not a case', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework_check")
 
 

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -128,6 +128,7 @@ class MyTestCase(unittest.TestCase):
                               ['30605', '', 'Maybe case issue', ''],
                               ['30606', '', 'case work', ''],
                               ['30607', '', 'For casework', ''],
+                              ['30607', '', 'For casewrk', ''],
                               ['30608', 'Closed Case', '', ''],
                               ['30609', 'Open Case', '', ''],
                               ['30610', '', 'Mary started case yesterday', 'Admin'],
@@ -146,6 +147,7 @@ class MyTestCase(unittest.TestCase):
                     ['30605', '', 'Maybe case issue', '', 'Casework'],
                     ['30606', '', 'case work', '', 'Casework'],
                     ['30607', '', 'For casework', '', 'Casework'],
+                    ['30607', '', 'For casewrk', '', 'Casework'],
                     ['30608', 'Closed Case', '', '', 'Casework'],
                     ['30609', 'Open Case', '', '', 'Casework'],
                     ['30610', '', 'Mary started case yesterday', 'Admin', 'Casework']]

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -39,35 +39,6 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for all casework, df_casework_check")
 
-    def test_casework(self):
-        """Test for when a column contains the word casework"""
-        # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', '', 'Just in case', ''],
-                              ['30601', '', 'Outgoing Info: casework, letter is x', ''],
-                              ['30602', '', 'Outgoing Info: letter is y', ''],
-                              ['30603', '', 'Answer topic x, forwarded original on to case work', ''],
-                              ['30604', '', 'Send down for casework', ''],
-                              ['30605', '', 'This is not casework', ''],
-                              ['casework', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic'])
-        df_casework, df_casework_check = find_casework_rows(md_df)
-
-        # Tests the values in df_casework are correct.
-        result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
-                    ['30601', '', 'Outgoing Info: casework, letter is x', '', 'Casework'],
-                    ['30604', '', 'Send down for casework', '', 'Casework'],
-                    ['30605', '', 'This is not casework', '', 'Casework'],
-                    ['casework', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for casework, df_casework")
-
-        # Tests the values in df_casework_check are correct.
-        result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
-                    ['30600', '', 'Just in case', '', 'Casework'],
-                    ['30603', '', 'Answer topic x, forwarded original on to case work', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for casework, df_casework_check")
-
     def test_in_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
@@ -153,8 +124,9 @@ class MyTestCase(unittest.TestCase):
                               ['30601', '', 'Already opened a case', ''],
                               ['30602', 'Closed Case', '', ''],
                               ['30603', 'Open Case', '', ''],
-                              ['30604', '', 'Mary started case yesterday', 'Admin'],
-                              ['30605', 'Roads', 'Not a case', '']],
+                              ['30604', '', 'For casework', ''],
+                              ['30605', '', 'Mary started case yesterday', 'Admin'],
+                              ['30606', 'Roads', 'Not a case', '']],
                              columns=['zip', 'in_topic', 'in_text', 'out_topic'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
@@ -165,13 +137,14 @@ class MyTestCase(unittest.TestCase):
                     ['30601', '', 'Already opened a case', '', 'Casework'],
                     ['30602', 'Closed Case', '', '', 'Casework'],
                     ['30603', 'Open Case', '', '', 'Casework'],
-                    ['30604', '', 'Mary started case yesterday', 'Admin', 'Casework']]
+                    ['30604', '', 'For casework', '', 'Casework'],
+                    ['30605', '', 'Mary started case yesterday', 'Admin', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'Appraisal_Category'],
-                    ['30605', 'Roads', 'Not a case', '', 'Casework']]
+                    ['30606', 'Roads', 'Not a case', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework_check")
 
 


### PR DESCRIPTION
Add additional indicators for what is casework to find_casework_rows():

- New phrases: “case closed”, “case for”, “case has been opened”, “case issue”, “case work” 
- Use casew instead of casework because of typos
- Entire cell is case or case!  (case insensitive) 