### PR TITLE
CSS arch appraisal check log

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -32,7 +32,6 @@ def appraisal_check_df(df, keyword, category):
     out_text = df['out_text'].str.contains(keyword, case=False, na=False)
 
     # Makes a dataframe with all rows containing the keyword in at least one of the six columns.
-    # TBD remove duplicates
     df_check = df[in_doc | in_fillin | in_text | out_doc | out_fillin | out_text].copy()
 
     # Adds a column with the category.

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -19,6 +19,28 @@ import sys
 import time
 
 
+def appraisal_check_df(df, keyword, category):
+    """Returns a df with all rows that contain the specified keyword in any of six columns,
+    including a category label"""
+
+    # Makes a series for each column with if each row contain the keyword (case-insensitive), excluding blanks.
+    in_doc = df['in_document_name'].str.contains(keyword, case=False, na=False)
+    in_fillin = df['in_fillin'].str.contains(keyword, case=False, na=False)
+    in_text = df['in_text'].str.contains(keyword, case=False, na=False)
+    out_doc = df['out_document_name'].str.contains(keyword, case=False, na=False)
+    out_fillin = df['out_fillin'].str.contains(keyword, case=False, na=False)
+    out_text = df['out_text'].str.contains(keyword, case=False, na=False)
+
+    # Makes a dataframe with all rows containing the keyword in at least one of the six columns.
+    # TBD remove duplicates
+    df_check = df[in_doc | in_fillin | in_text | out_doc | out_fillin | out_text].copy()
+
+    # Adds a column with the category.
+    df_check['Appraisal_Category'] = category
+
+    return df_check
+
+
 def check_arguments(arg_list):
     """Verify the required script arguments are present and valid and get the path to the metadata file"""
 

--- a/documentation/workflow.md
+++ b/documentation/workflow.md
@@ -20,9 +20,10 @@ During the initial review, determine if the export meets acceptance guidelines.
 1. Check the appraisal reports made during review for errors (based on file names) in what will be deleted or not delete.
 2. Refine the script to catch new patterns, but some errors are acceptable given the scale.
 3. Update the function update_path() for transforming the metadata path into the directory path, if needed.
-4. Run the script in "appraisal" mode to delete letters flagged for appraisal. The metadata is not changed.
-5. Delete any folders that are labeled casework and document those deleted files (probably with accessioning script).
-6. Delete any metadata files that are just for casework.
+4. Run the script in "accession" mode again to check your changes. It takes a long time to recopy an export if there are mistakes with deletion (next step).
+5. Run the script in "appraisal" mode to delete letters flagged for appraisal. The metadata is not changed.
+6. Delete any folders that are labeled casework and document those deleted files (probably with accessioning script).
+7. Delete any metadata files that are just for casework.
 
 Continue with the standard accessioning workflow to complete the accession.
 

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -70,5 +70,6 @@ class MyTestCase(unittest.TestCase):
                      'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for no column")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -10,6 +10,25 @@ from test_read_metadata import df_to_list
 
 class MyTestCase(unittest.TestCase):
 
+    def test_multiple_columns(self):
+        """Test for when the keyword is in multiple columns per row"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
+                           ['30601', 'CASE', r'doc\Case_File.txt', '', '', r'form\a.txt', ''],
+                           ['30602', '', '', r'doc\file3.txt', 'Note', '', ''],
+                           ['30603', '', '', '', 'started case Tue', r'case\abc.txt', 'Mr._Case']],
+                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_text', 'out_document_name', 'out_fillin'])
+        df_check = appraisal_check_df(df, 'case', 'Casework')
+
+        # Tests the values in df_check are correct.
+        result = df_to_list(df_check)
+        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
+                     'Appraisal_Category'],
+                    ['30601', 'CASE', r'doc\Case_File.txt', '', '', r'form\a.txt', '', 'Casework'],
+                    ['30603', '', '', '', 'started case Tue', r'case\abc.txt', 'Mr._Case', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for one column")
+
     def test_one_column(self):
         """Test for when the keyword is in one column per row"""
         # Makes a dataframe to use as test input and runs the function.

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -54,6 +54,21 @@ class MyTestCase(unittest.TestCase):
                     ['30606', '', '', r'doc\file4.txt', 'Note', r'letter\123.txt', 'Mr._Case', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one column")
 
+    def test_no_column(self):
+        """Test for when the keyword is in no columns"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
+                           ['30602', 'note', '', '', '', r'form\a.txt', ''],
+                           ['30603', '', '', '', 'started Tue', '', 'a_b']],
+                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_text', 'out_document_name', 'out_fillin'])
+        df_check = appraisal_check_df(df, 'case', 'Casework')
+
+        # Tests the values in df_check are correct.
+        result = df_to_list(df_check)
+        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
+                     'Appraisal_Category']]
+        self.assertEqual(result, expected, "Problem with test for no column")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -1,0 +1,40 @@
+"""
+Tests for the function appraisal_check_df, which makes a df of all rows to check for possible appraisal.
+Tests for check df for the four categories of appraisal are part of the "find_category_rows" tests.
+"""
+import pandas as pd
+import unittest
+from css_archiving_format import appraisal_check_df
+from test_read_metadata import df_to_list
+
+
+class MyTestCase(unittest.TestCase):
+
+    def test_one_column(self):
+        """Test for when the keyword is in one column per row"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
+                           ['30601', 'CASE', '', '', '', r'form\a.txt', ''],
+                           ['30602', 'note', r'doc\Case_File.txt', '', '', '', ''],
+                           ['30603', '', '', '', 'started case Tue', '', 'a_b'],
+                           ['30604', 'note', r'doc\file2.txt', '', 'reply note', r'case\abc.txt', ''],
+                           ['30605', '', '', r'doc\file3.txt', 'Note', '', ''],
+                           ['30606', '', '', r'doc\file4.txt', 'Note', r'letter\123.txt', 'Mr._Case']],
+                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_text', 'out_document_name', 'out_fillin'])
+        df_check = appraisal_check_df(df, 'case', 'Casework')
+
+        # Tests the values in df_check are correct.
+        result = df_to_list(df_check)
+        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
+                     'Appraisal_Category'],
+                    ['30601', 'CASE', '', '', '', r'form\a.txt', '', 'Casework'],
+                    ['30602', 'note', r'doc\Case_File.txt', '', '', '', '', 'Casework'],
+                    ['30603', '', '', '', 'started case Tue', '', 'a_b', 'Casework'],
+                    ['30604', 'note', r'doc\file2.txt', '', 'reply note', r'case\abc.txt', '', 'Casework'],
+                    ['30606', '', '', r'doc\file4.txt', 'Note', r'letter\123.txt', 'Mr._Case', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for one column")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/css_archiving_format/test_find_academy_rows.py
+++ b/tests/css_archiving_format/test_find_academy_rows.py
@@ -14,151 +14,179 @@ class MyTestCase(unittest.TestCase):
     def test_all(self):
         """Test for when all patterns indicating academy applications are present"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'For academy nomination', 'Military Service Academy',
-                               'ACADEMY NOMINATION'],
-                              ['30601', 'Military Service Academy^Admin', '', 'Military Service Academy', ''],
-                              ['30602', 'Academy Applicant', '', 'Academy Applicant^Gen', 'Academy Nomination Letter'],
-                              ['30603', '', 'academy nomination', '', 'For academy nomination support'],
-                              ['30604', '', 'academy nomination', 'Academy Applicant', 'academy nomination']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'For academy nomination', '', '',
+                               'Military Service Academy', 'ACADEMY NOMINATION', '', ''],
+                              ['30601', 'Military Service Academy^Admin', '', '', '', 'Military Service Academy',
+                               '', '', ''],
+                              ['30602', 'Academy Applicant', '', '', '', 'Academy Applicant^Gen',
+                               'Academy Nomination Letter', '', ''],
+                              ['30603', '', 'academy nomination', '', '', '', 'For academy nomination support', '', ''],
+                              ['30604', '', 'academy nomination', '', '', 'Academy Applicant', 'academy nomination',
+                               '', ''],
+                              ['30605', 'Admin', 'academy', '', '', 'Admin', '', '', ''],
+                              ['30606', 'Admin', '', '', '', 'Admin', '', r'doc\academy_voucher.txt', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
         
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'For academy nomination', 'Military Service Academy',
-                     'ACADEMY NOMINATION', 'Academy_Application'],
-                    ['30601', 'Military Service Academy^Admin', '', 'Military Service Academy', '',
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Academy Applicant', 'For academy nomination', '', '', 'Military Service Academy',
+                     'ACADEMY NOMINATION', '', '', 'Academy_Application'],
+                    ['30601', 'Military Service Academy^Admin', '', '', '', 'Military Service Academy', '', '', '',
                      'Academy_Application'],
-                    ['30602', 'Academy Applicant', '', 'Academy Applicant^Gen', 'Academy Nomination Letter',
+                    ['30602', 'Academy Applicant', '', '', '', 'Academy Applicant^Gen', 'Academy Nomination Letter',
+                     '', '', 'Academy_Application'],
+                    ['30604', '', 'academy nomination', '', '', 'Academy Applicant', 'academy nomination', '', '',
                      'Academy_Application'],
-                    ['30604', '', 'academy nomination', 'Academy Applicant', 'academy nomination',
-                     'Academy_Application'],
-                    ['30603', '', 'academy nomination', '', 'For academy nomination support',
+                    ['30603', '', 'academy nomination', '', '', '', 'For academy nomination support', '', '',
                      'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30605', 'Admin', 'academy', '', '', 'Admin', '', '', '', 'Academy_Application'],
+                    ['30606', 'Admin', '', '', '', 'Admin', '', r'doc\academy_voucher.txt', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_academy_check")
 
     def test_in_text(self):
         """Test for when column in_text contains "academy nomination" (cass-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Military', 'For Academy Nomination Letter', 'Military', ''],
-                              ['30601', 'Economy', '', 'Economy', ''],
-                              ['30602', 'Admin', 'academy nomination', '', 'note'],
-                              ['30603', 'Arts', 'Arts academy', 'Arts', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Military', 'For Academy Nomination Letter', '', '', 'Military', '', '', ''],
+                              ['30601', 'Economy', '', '', '', 'Economy', '', '', ''],
+                              ['30602', 'Admin', 'academy nomination', '', '', '', 'note', '', ''],
+                              ['30603', 'Arts', 'Arts academy', '', '', 'Arts', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
 
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Military', 'For Academy Nomination Letter', 'Military', '', 'Academy_Application'],
-                    ['30602', 'Admin', 'academy nomination', '', 'note', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Military', 'For Academy Nomination Letter', '', '', 'Military', '', '', '',
+                     'Academy_Application'],
+                    ['30602', 'Admin', 'academy nomination', '', '', '', 'note', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30603', 'Arts', 'Arts academy', 'Arts', '', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', 'Arts', 'Arts academy', '', '', 'Arts', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_academy_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains one of the topics indicating academy applications"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Science Academy', '', 'Water', ''],
-                              ['30601', 'Military Service Academy', '', 'Admin', ''],
-                              ['30602', 'Military^Academy Applicant', '', '', ''],
-                              ['30603', 'Arts', '', '', ''],
-                              ['30604', 'Military Service Academy^ADMIN', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Science Academy', '', '', '', 'Water', '', '', ''],
+                              ['30601', 'Military Service Academy', '', '', '', 'Admin', '', '', ''],
+                              ['30602', 'Military^Academy Applicant', '', '', '', '', '', '', ''],
+                              ['30603', 'Arts', '', '', '', '', '', '', ''],
+                              ['30604', 'Military Service Academy^ADMIN', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
 
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30601', 'Military Service Academy', '', 'Admin', '', 'Academy_Application'],
-                    ['30602', 'Military^Academy Applicant', '', '', '', 'Academy_Application'],
-                    ['30604', 'Military Service Academy^ADMIN', '', '', '', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'Military Service Academy', '', '', '', 'Admin', '', '', '', 'Academy_Application'],
+                    ['30602', 'Military^Academy Applicant', '', '', '', '', '', '', '', 'Academy_Application'],
+                    ['30604', 'Military Service Academy^ADMIN', '', '', '', '', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Science Academy', '', 'Water', '', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Science Academy', '', '', '', 'Water', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_academy_check")
 
     def test_none(self):
         """Test for when no patterns indicating academy applications are present"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Arts', 'Note', 'Arts', 'Note'],
-                              ['30601', 'Water', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+                              ['30601', 'Water', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
 
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text', 
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_academy_check")
 
     def test_out_text(self):
         """Test for when column out_text contains "academy nomination" (cass-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', '', '', '', 'for academy nomination'],
-                              ['30601', '', 'note', '', 'Academy Nomination acceptance'],
-                              ['30602', 'Military', '', '', 'ACADEMY NOMINATION'],
-                              ['30603', 'Arts', 'Note', 'Arts', 'Academy Note'],
-                              ['30604', 'Science', '', 'Science', 'International Science Academy']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', '', '', '', '', '', 'for academy nomination', '', ''],
+                              ['30601', '', 'note', '', '', '', 'Academy Nomination acceptance', '', ''],
+                              ['30602', 'Military', '', '', '', '', 'ACADEMY NOMINATION', '', ''],
+                              ['30603', 'Arts', 'Note', '', '', 'Arts', 'Academy Note', '', ''],
+                              ['30604', 'Science', '', '', '', 'Science', 'International Science Academy', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
 
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', '', '', '', 'for academy nomination', 'Academy_Application'],
-                    ['30601', '', 'note', '', 'Academy Nomination acceptance', 'Academy_Application'],
-                    ['30602', 'Military', '', '', 'ACADEMY NOMINATION', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', '', '', '', '', '', 'for academy nomination', '', '', 'Academy_Application'],
+                    ['30601', '', 'note', '', '', '', 'Academy Nomination acceptance', '', '', 'Academy_Application'],
+                    ['30602', 'Military', '', '', '', '', 'ACADEMY NOMINATION', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30603', 'Arts', 'Note', 'Arts', 'Academy Note', 'Academy_Application'],
-                    ['30604', 'Science', '', 'Science', 'International Science Academy', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', 'Arts', 'Note', '', '', 'Arts', 'Academy Note', '', '', 'Academy_Application'],
+                    ['30604', 'Science', '', '', '', 'Science', 'International Science Academy', '', '',
+                     'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_academy_check")
 
     def test_out_topic(self):
         """Test for when column out_topic contains one of the topics indicating academy applications"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Transportation', '', 'Academy', ''],
-                              ['30601', 'General', '', 'General^Military Service Academy', ''],
-                              ['30602', 'General', '', 'Science Academy', 'Note'],
-                              ['30603', '', '', 'Academy Applicant^Military', ''],
-                              ['30604', '', '', 'Academy Applicant', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Transportation', '', '', '', 'Academy', '', '', ''],
+                              ['30601', 'General', '', '', '', 'General^Military Service Academy', '', '', ''],
+                              ['30602', 'General', '', '', '', 'Science Academy', 'Note', '', ''],
+                              ['30603', '', '', '', '', 'Academy Applicant^Military', '', '', ''],
+                              ['30604', '', '', '', '', 'Academy Applicant', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
 
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30601', 'General', '', 'General^Military Service Academy', '', 'Academy_Application'],
-                    ['30603', '', '', 'Academy Applicant^Military', '', 'Academy_Application'],
-                    ['30604', '', '', 'Academy Applicant', '', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'General', '', '', '', 'General^Military Service Academy', '', '', '',
+                     'Academy_Application'],
+                    ['30603', '', '', '', '', 'Academy Applicant^Military', '', '', '', 'Academy_Application'],
+                    ['30604', '', '', '', '', 'Academy Applicant', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Transportation', '', 'Academy', '', 'Academy_Application'],
-                    ['30602', 'General', '', 'Science Academy', 'Note', 'Academy_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Transportation', '', '', '', 'Academy', '', '', '', 'Academy_Application'],
+                    ['30602', 'General', '', '', '', 'Science Academy', 'Note', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_academy_check")
 
 

--- a/tests/css_archiving_format/test_find_appraisal_rows.py
+++ b/tests/css_archiving_format/test_find_appraisal_rows.py
@@ -26,229 +26,255 @@ class MyTestCase(unittest.TestCase):
         """Test for when there are all four categories for appraisal
         (academy applications, casework, job application, recommendations)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', ''],
-                              ['30601', 'General', 'Note', '', 'General', 'Note', ''],
-                              ['30602', 'Casework', '', '', '', '', ''],
-                              ['30603', 'Admin', '', '', 'Recommendations', 'wrote recommendation', ''],
-                              ['30604', 'Social Security', 'Casework candidate', '', '', '', ''],
-                              ['30605', 'Intern', '', r'..\doc\resume.txt', 'job request', '', ''],
-                              ['30606', 'Congratulations', '', '', '', '', 'Good job'],
-                              ['30607', 'Legislation', '', '', '', '', 'Recommendation noted'],
-                              ['30608', 'Arts', 'International Academy', '', '', '', ''],
-                              ['30609', 'Legal', 'Case against Napster', '', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', ''],
+                              ['30601', 'General', 'Note', '', '', 'General', 'Note', '', ''],
+                              ['30602', 'Casework', '', '', '', '', '', '', ''],
+                              ['30603', 'Admin', '', '', '', 'Recommendations', 'wrote recommendation', '', ''],
+                              ['30604', 'Social Security', 'Casework candidate', '', '', '', '', '', ''],
+                              ['30605', 'Intern', '', r'..\doc\resume.txt', '', '', 'job request', '', ''],
+                              ['30606', 'Congratulations', '', '', '', '', 'Good job', '', ''],
+                              ['30607', 'Legislation', '', '', '', '', 'Recommendation noted', '', ''],
+                              ['30608', 'Arts', 'International Academy', '', '', '', '', '', ''],
+                              ['30609', 'Legal', 'Case against Napster', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values of the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', 'Academy_Application'],
-                    ['30602', 'Casework', '', '', '', '', '', 'Casework'],
-                    ['30603', 'Admin', '', '', 'Recommendations', 'wrote recommendation', '', 'Recommendation'],
-                    ['30604', 'Social Security', 'Casework candidate', '', '', '', '', 'Casework'],
-                    ['30605', 'Intern', '', r'..\doc\resume.txt', 'job request', '', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', '', 'Academy_Application'],
+                    ['30602', 'Casework', '', '', '', '', '', '', '', 'Casework'],
+                    ['30603', 'Admin', '', '', '', 'Recommendations', 'wrote recommendation', '', '', 'Recommendation'],
+                    ['30604', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework'],
+                    ['30605', 'Intern', '', r'..\doc\resume.txt', '', '', 'job request', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for four categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
-                    [30602, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30603, 'Admin', 'BLANK', 'BLANK', 'Recommendations', 'wrote recommendation', 'BLANK', 'Recommendation'],
-                    [30604, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30605, 'Intern', 'BLANK', r'..\doc\resume.txt', 'job request', 'BLANK', 'BLANK', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Academy_Application'],
+                    [30602, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Admin', 'BLANK', 'BLANK', 'BLANK', 'Recommendations', 'wrote recommendation', 'BLANK',
+                     'BLANK', 'Recommendation'],
+                    [30604, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'BLANK', 'Casework'],
+                    [30605, 'Intern', 'BLANK', r'..\doc\resume.txt', 'BLANK', 'BLANK', 'job request', 'BLANK',
+                     'BLANK', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30608, 'Arts', 'International Academy', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
-                    [30609, 'Legal', 'Case against Napster', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30606, 'Congratulations', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Good job', 'Job_Application'],
-                    [30607, 'Legislation', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Recommendation noted', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30608, 'Arts', 'International Academy', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Academy_Application'],
+                    [30609, 'Legal', 'Case against Napster', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Casework'],
+                    [30606, 'Congratulations', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Good job', 'BLANK', 'BLANK',
+                     'Job_Application'],
+                    [30607, 'Legislation', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Recommendation noted', 'BLANK',
+                     'BLANK', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_three(self):
         """Test for when there are three categories for appraisal (academy applications, casework, job application)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', ''],
-                              ['30601', 'Casework', '', '', '', '', ''],
-                              ['30602', 'General', 'Note', '', 'General', 'Note', ''],
-                              ['30603', 'Social Security', 'Casework candidate', '', '', '', ''],
-                              ['30604', 'Intern', '', '', 'job request', '', r'..\doc\resume.txt'],
-                              ['30605', 'Judicial', 'Napster case', '', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', ''],
+                              ['30601', 'Casework', '', '', '', '', '', '', ''],
+                              ['30602', 'General', 'Note', '', '', 'General', 'Note', '', ''],
+                              ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', ''],
+                              ['30604', 'Intern', '', '', '', 'job request', '', r'..\doc\resume.txt', ''],
+                              ['30605', 'Judicial', 'Napster case', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values of the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', 'Academy_Application'],
-                    ['30601', 'Casework', '', '', '', '', '', 'Casework'],
-                    ['30603', 'Social Security', 'Casework candidate', '', '', '', '', 'Casework'],
-                    ['30604', 'Intern', '', '', 'job request', '', r'..\doc\resume.txt', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', '', 'Academy_Application'],
+                    ['30601', 'Casework', '', '', '', '', '', '', '', 'Casework'],
+                    ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework'],
+                    ['30604', 'Intern', '', '', '', 'job request', '', r'..\doc\resume.txt', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for three categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
-                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30604, 'Intern', 'BLANK', 'BLANK', 'job request', 'BLANK', r'..\doc\resume.txt', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Academy_Application'],
+                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'BLANK', 'Casework'],
+                    [30604, 'Intern', 'BLANK', 'BLANK', 'BLANK', 'job request', 'BLANK', r'..\doc\resume.txt',
+                     'BLANK', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for three categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30605, 'Judicial', 'Napster case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30605, 'Judicial', 'Napster case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_two(self):
         """Test for when there are two categories for appraisal (academy applications and casework)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', ''],
-                              ['30601', 'Casework', '', '', '', '', ''],
-                              ['30602', 'General', 'Note', '', 'General', 'Note', ''],
-                              ['30603', 'Social Security', 'Casework candidate', '', '', '', ''],
-                              ['30604', 'Culture', 'Academy Awards', '', '', '', ''],
-                              ['30605', 'Farming', '', '', '', '', r'..\doc\case\file.doc']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', ''],
+                              ['30601', 'Casework', '', '', '', '', '', '', ''],
+                              ['30602', 'General', 'Note', '', '', 'General', 'Note', '', ''],
+                              ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', ''],
+                              ['30604', 'Culture', 'Academy Awards', '', '', '', '', '', ''],
+                              ['30605', 'Farming', '', '', '', '', '', r'..\doc\case\file.doc', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values of the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', 'Academy_Application'],
-                    ['30601', 'Casework', '', '', '', '', '', 'Casework'],
-                    ['30603', 'Social Security', 'Casework candidate', '', '', '', '', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', '', 'Academy_Application'],
+                    ['30601', 'Casework', '', '', '', '', '', '', '', 'Casework'],
+                    ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for two categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
-                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30600, 'Academy Applicant', 'Nomination', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Academy_Application'],
+                    [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
+                    [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for two categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30604, 'Culture', 'Academy Awards', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Academy_Application'],
-                    [30605, 'Farming', 'BLANK', 'BLANK', 'BLANK', 'BLANK', r'..\doc\case\file.doc', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30604, 'Culture', 'Academy Awards', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Academy_Application'],
+                    [30605, 'Farming', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', r'..\doc\case\file.doc', 'BLANK',
+                     'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_one(self):
         """Test for when there is one category for appraisal (casework)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Casework Issues', '', '', 'Casework', '', ''],
-                              ['30601', 'Health^Casework', 'Note', '', '', '', ''],
-                              ['30602', 'Health', 'General interest', '', '', 'Note', ''],
-                              ['30603', 'Social Security', 'Open Case', '', '', '', ''],
-                              ['30604', 'Admin', '', '', '', 'For Casey', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Casework Issues', '', '', '', 'Casework', '', '', ''],
+                              ['30601', 'Health^Casework', 'Note', '', '', '', '', '', ''],
+                              ['30602', 'Health', 'General interest', '', '', '', 'Note', '', ''],
+                              ['30603', 'Social Security', 'Open Case', '', '', '', '', '', ''],
+                              ['30604', 'Admin', '', '', '', '', 'For Casey', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values in the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Casework Issues', '', '', 'Casework', '', '', 'Casework'],
-                    ['30601', 'Health^Casework', 'Note', '', '', '', '', 'Casework'],
-                    ['30603', 'Social Security', 'Open Case', '', '', '', '', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Casework Issues', '', '', '', 'Casework', '', '', '', 'Casework'],
+                    ['30601', 'Health^Casework', 'Note', '', '', '', '', '', '', 'Casework'],
+                    ['30603', 'Social Security', 'Open Case', '', '', '', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one category, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30600, 'Casework Issues', 'BLANK', 'BLANK', 'Casework', 'BLANK', 'BLANK', 'Casework'],
-                    [30601, 'Health^Casework', 'Note', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
-                    [30603, 'Social Security', 'Open Case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30600, 'Casework Issues', 'BLANK', 'BLANK', 'BLANK', 'Casework', 'BLANK', 'BLANK',
+                     'BLANK', 'Casework'],
+                    [30601, 'Health^Casework', 'Note', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'Casework'],
+                    [30603, 'Social Security', 'Open Case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one category, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30604, 'Admin', 'BLANK', 'BLANK', 'BLANK', 'For Casey', 'BLANK', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30604, 'Admin', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'For Casey', 'BLANK', 'BLANK', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_none(self):
         """Test for when there are no indicators for appraisal"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Arts', 'In support', '', '', '', ''],
-                              ['30601', 'Healthcare', '', '', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Arts', 'In support', '', '', '', '', '', ''],
+                              ['30601', 'Healthcare', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values in the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for no appraisal, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for no appraisal, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
 
     def test_multiple(self):
         """Test for when there are rows that match multiple categories for appraisal"""
-        md_df = pd.DataFrame([['30600', 'Casework^Academy Applicant', '', '', '', '', ''],
-                              ['30601', 'Academy Applicant', 'Maybe casework', '', '', 'rec for doe', ''],
-                              ['30602', 'Legal Case', '', '', 'Congrats', 'Good job', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Casework^Academy Applicant', '', '', '', '', '', '', ''],
+                              ['30601', 'Academy Applicant', 'Maybe casework', '', '', '', 'rec for doe', '', ''],
+                              ['30602', 'Legal Case', '', '', '', 'Congrats', 'Good job', '', ''],
+                              ['30603', 'Admin', 'note', r'doc\case.txt', '', 'Admin', 'recommendation', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         appraisal_df = find_appraisal_rows(md_df, 'test_data')
 
         # Tests the values of the returned dataframe are correct.
         result = df_to_list(appraisal_df)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Casework^Academy Applicant', '', '', '', '', '', 'Academy_Application|Casework'],
-                    ['30601', 'Academy Applicant', 'Maybe casework', '', '', 'rec for doe', '',
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Casework^Academy Applicant', '', '', '', '', '', '', '', 'Academy_Application|Casework'],
+                    ['30601', 'Academy Applicant', 'Maybe casework', '', '', '', 'rec for doe', '', '',
                      'Academy_Application|Casework|Recommendation']]
         self.assertEqual(result, expected, "Problem with test for multiple categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30600, 'Casework^Academy Applicant', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
-                     'Academy_Application|Casework'],
-                    [30601, 'Academy Applicant', 'Maybe casework', 'BLANK', 'BLANK', 'rec for doe', 'BLANK',
-                     'Academy_Application|Casework|Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30600, 'Casework^Academy Applicant', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
+                     'BLANK', 'Academy_Application|Casework'],
+                    [30601, 'Academy Applicant', 'Maybe casework', 'BLANK', 'BLANK', 'BLANK', 'rec for doe', 'BLANK',
+                     'BLANK', 'Academy_Application|Casework|Recommendation']]
         self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    [30602, 'Legal Case', 'BLANK', 'BLANK', 'Congrats', 'Good job', 'BLANK', 'Casework'],
-                    [30602, 'Legal Case', 'BLANK', 'BLANK', 'Congrats', 'Good job', 'BLANK', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    [30602, 'Legal Case', 'BLANK', 'BLANK', 'BLANK', 'Congrats', 'Good job', 'BLANK', 'BLANK',
+                     'Casework'],
+                    [30603, 'Admin', 'note', r'doc\case.txt', 'BLANK', 'Admin', 'recommendation', 'BLANK', 'BLANK',
+                     'Casework'],
+                    [30602, 'Legal Case', 'BLANK', 'BLANK', 'BLANK', 'Congrats', 'Good job', 'BLANK', 'BLANK',
+                     'Job_Application'],
+                    [30603, 'Admin', 'note', r'doc\case.txt', 'BLANK', 'Admin', 'recommendation', 'BLANK', 'BLANK',
+                     'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for multiple categories, appraisal check log")
 
 

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -14,177 +14,199 @@ class MyTestCase(unittest.TestCase):
     def test_all_casework(self):
         """Test for every type of pattern indicating casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Casework Issues', 'note', 'Issues'],
-                              ['30601', 'SSA', 'Jan added to case', 'SSA'],
-                              ['30602', 'Health', 'This is casework', 'Casework^Medical'],
-                              ['30603', 'Health', 'open case', ''],
-                              ['30604', '', 'Started case Wed', 'Admin'],
-                              ['30605', 'Prison Case', '', 'Casework']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30600', 'Casework Issues', 'new case', r'doc\case.txt', '', 'Issues', 'note', '', ''],
+                              ['30601', 'SSA', '', '', '', 'SSA', 'Jan added to case', '', 'case Jan'],
+                              ['30602', 'Health', '', '', '', 'Casework^Medical', 'This is casework', '', ''],
+                              ['30603', 'Health', '', '', '', '', 'open case', '', ''],
+                              ['30604', '', '', '', '', 'Admin', 'Started case Wed', '', ''],
+                              ['30605', 'Prison Case', '', '', '', 'Casework', '', '', ''],
+                              ['30606', 'Admin', 'new case', '', '', 'Admin', 'note', '', 'thank you_case'],
+                              ['30607', 'Admin', 'note', '', '', '', '', r'case\file.txt', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30600', 'Casework Issues', 'note', 'Issues', 'Casework'],
-                    ['30605', 'Prison Case', '', 'Casework', 'Casework'],
-                    ['30602', 'Health', 'This is casework', 'Casework^Medical', 'Casework'],
-                    ['30601', 'SSA', 'Jan added to case', 'SSA', 'Casework'],
-                    ['30603', 'Health', 'open case', '', 'Casework'],
-                    ['30604', '', 'Started case Wed', 'Admin', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Casework Issues', 'new case', r'doc\case.txt', '', 'Issues', 'note', '', '', 'Casework'],
+                    ['30605', 'Prison Case', '', '', '', 'Casework', '', '', '', 'Casework'],
+                    ['30602', 'Health', '', '', '', 'Casework^Medical', 'This is casework', '', '', 'Casework'],
+                    ['30601', 'SSA', '', '', '', 'SSA', 'Jan added to case', '', 'case Jan', 'Casework'],
+                    ['30603', 'Health', '', '', '', '', 'open case', '', '', 'Casework'],
+                    ['30604', '', '', '', '', 'Admin', 'Started case Wed', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for all casework, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30606', 'Admin', 'new case', '', '', 'Admin', 'note', '', 'thank you_case', 'Casework'],
+                    ['30607', 'Admin', 'note', '', '', '', '', r'case\file.txt', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for all casework, df_casework_check")
 
     def test_in_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Casework', '', 'Admin'],
-                              ['30601', 'Keep', 'note', ''],
-                              ['30602', 'Casework Issues', '', 'Admin'],
-                              ['30603', 'Prison Case', 'note', 'Justice'],
-                              ['30604', 'Healthcare^Casework', '', 'Health'],
-                              ['30605', 'Casework Issues^Social Security', 'note', 'SSA'],
-                              ['30606', 'Prison Case^No Reply', '', 'Justice'],
-                              ['30607', 'Keep', 'CASE OF THE CENTURY', 'Legal'],
-                              ['30608', 'Casework^Casework Issues', '', 'Admin']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30600', 'Casework', '', '', '', 'Admin', '', '', ''],
+                              ['30601', 'Keep', '', '', '', '', 'note', '', ''],
+                              ['30602', 'Casework Issues', '', '', '', 'Admin', '', '', ''],
+                              ['30603', 'Prison Case', '', '', '', 'Justice', 'note', '', ''],
+                              ['30604', 'Healthcare^Casework', '', '', '', 'Health', '', '', ''],
+                              ['30605', 'Casework Issues^Social Security', '', '', '', 'SSA', 'note', '', ''],
+                              ['30606', 'Prison Case^No Reply', '', '', '', 'Justice', '', '', ''],
+                              ['30607', 'Keep', '', '', '', 'Legal', 'CASE OF THE CENTURY', '', ''],
+                              ['30608', 'Casework^Casework Issues', '', '', '', 'Admin', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30600', 'Casework', '', 'Admin', 'Casework'],
-                    ['30602', 'Casework Issues', '', 'Admin', 'Casework'],
-                    ['30603', 'Prison Case', 'note', 'Justice', 'Casework'],
-                    ['30604', 'Healthcare^Casework', '', 'Health', 'Casework'],
-                    ['30605', 'Casework Issues^Social Security', 'note', 'SSA', 'Casework'],
-                    ['30606', 'Prison Case^No Reply', '', 'Justice', 'Casework'],
-                    ['30608', 'Casework^Casework Issues', '', 'Admin', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Casework', '', '', '', 'Admin', '', '', '', 'Casework'],
+                    ['30602', 'Casework Issues', '', '', '', 'Admin', '', '', '', 'Casework'],
+                    ['30603', 'Prison Case', '', '', '', 'Justice', 'note', '', '', 'Casework'],
+                    ['30604', 'Healthcare^Casework', '', '', '', 'Health', '', '', '', 'Casework'],
+                    ['30605', 'Casework Issues^Social Security', '', '', '', 'SSA', 'note', '', '', 'Casework'],
+                    ['30606', 'Prison Case^No Reply', '', '', '', 'Justice', '', '', '', 'Casework'],
+                    ['30608', 'Casework^Casework Issues', '', '', '', 'Admin', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30607', 'Keep', 'CASE OF THE CENTURY', 'Legal', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30607', 'Keep', '', '', '', 'Legal', 'CASE OF THE CENTURY', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_casework_check")
 
     def test_none(self):
         """Test for when there are no indicators of casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Keep', '', 'Keep'],
-                              ['30601', 'Healthcare', '', 'Healthcare']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30600', 'Keep', '', '', '', '', 'Keep', '', ''],
+                              ['30601', 'Healthcare', '', '', '', 'Healthcare', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework_check")
 
     def test_out_text(self):
         """Test for when the column out_text is equal to a keyword that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30601', '', 'Case!', ''],
-                              ['30602', 'Admin', 'CASE', ''],
-                              ['30603', '', 'Not case', ''],
-                              ['30604', '', 'case!', ''],
-                              ['30605', '', 'Just in case', 'Admin'],
-                              ['30606', '', 'case', '']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30601', '', '', '', '', '', 'Case!', '', ''],
+                              ['30602', 'Admin', '', '', '', '', 'CASE', '', ''],
+                              ['30603', '', '', '', '', '', 'Not case', '', ''],
+                              ['30604', '', '', '', '', '', 'case!', '', ''],
+                              ['30605', '', '', '', '', 'Admin', 'Just in case', '', ''],
+                              ['30606', '', '', '', '', '', 'case', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30601', '', 'Case!', '', 'Casework'],
-                    ['30602', 'Admin', 'CASE', '', 'Casework'],
-                    ['30604', '', 'case!', '', 'Casework'],
-                    ['30606', '', 'case', '', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', '', '', '', '', '', 'Case!', '', '', 'Casework'],
+                    ['30602', 'Admin', '', '', '', '', 'CASE', '', '', 'Casework'],
+                    ['30604', '', '', '', '', '', 'case!', '', '', 'Casework'],
+                    ['30606', '', '', '', '', '', 'case', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30603', '', 'Not case', '', 'Casework'],
-                    ['30605', '', 'Just in case', 'Admin', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', '', '', '', '', '', 'Not case', '', '', 'Casework'],
+                    ['30605', '', '', '', '', 'Admin', 'Just in case', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_casework_check")
 
     def test_out_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Admin', '', 'Casework'],
-                              ['30601', 'Admin', '', 'Healthcare^Casework'],
-                              ['30602', 'SSA', 'note', 'Casework Issues^Social Security'],
-                              ['30603', '', '', 'Prison Case'],
-                              ['30604', '', '', 'Casework^Casework Issues'],
-                              ['30605', 'Admin', '', '']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30600', 'Admin', '', '', '', 'Casework', '', '', ''],
+                              ['30601', 'Admin', '', '', '', 'Healthcare^Casework', '', '', ''],
+                              ['30602', 'SSA', '', '', '', 'Casework Issues^Social Security', 'note', '', ''],
+                              ['30603', '', '', '', '', 'Prison Case', '', '', ''],
+                              ['30604', '', '', '', '', 'Casework^Casework Issues', '', '', ''],
+                              ['30605', 'Admin', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30600', 'Admin', '', 'Casework', 'Casework'],
-                    ['30601', 'Admin', '', 'Healthcare^Casework', 'Casework'],
-                    ['30602', 'SSA', 'note', 'Casework Issues^Social Security', 'Casework'],
-                    ['30603', '', '', 'Prison Case', 'Casework'],
-                    ['30604', '', '', 'Casework^Casework Issues', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Admin', '', '', '', 'Casework', '', '', '', 'Casework'],
+                    ['30601', 'Admin', '', '', '', 'Healthcare^Casework', '', '', '', 'Casework'],
+                    ['30602', 'SSA', '', '', '', 'Casework Issues^Social Security', 'note', '', '', 'Casework'],
+                    ['30603', '', '', '', '', 'Prison Case', '', '', '', 'Casework'],
+                    ['30604', '', '', '', '', 'Casework^Casework Issues', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_casework_check")
 
     def test_phase(self):
         """Test for when a column contains a phrase that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', '', 'I added to case', ''],
-                              ['30601', '', 'Already opened a case', ''],
-                              ['30602', '', 'CASE CLOSED', ''],
-                              ['30603', '', 'Case for doe', ''],
-                              ['30604', '', 'A case has been opened', ''],
-                              ['30605', '', 'Maybe case issue', ''],
-                              ['30606', '', 'case work', ''],
-                              ['30607', '', 'For casework', ''],
-                              ['30607', '', 'For casewrk', ''],
-                              ['30608', 'Closed Case', '', ''],
-                              ['30609', 'Open Case', '', ''],
-                              ['30610', '', 'Mary started case yesterday', 'Admin'],
-                              ['30611', 'Roads', 'Not a case', '']],
-                             columns=['zip', 'in_topic', 'out_text', 'out_topic'])
+        md_df = pd.DataFrame([['30600', '', '', '', '', '', 'I added to case', '', ''],
+                              ['30601', '', '', '', '', '', 'Already opened a case', '', ''],
+                              ['30602', '', '', '', '', '', 'CASE CLOSED', '', ''],
+                              ['30603', '', '', '', '', '', 'Case for doe', '', ''],
+                              ['30604', '', '', '', '', '', 'A case has been opened', '', ''],
+                              ['30605', '', '', '', '', '', 'Maybe case issue', '', ''],
+                              ['30606', '', '', '', '', '', 'case work', '', ''],
+                              ['30607', '', '', '', '', '', 'For casework', '', ''],
+                              ['30607', '', '', '', '', '', 'For casewrk', '', ''],
+                              ['30608', 'Closed Case', '', '', '', '', '', '', ''],
+                              ['30609', 'Open Case', '', '', '', '', '', '', ''],
+                              ['30610', '', '', '', '', 'Admin', 'Mary started case yesterday', '', ''],
+                              ['30611', 'Roads', '', '', '', '', 'Not a case', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_casework, df_casework_check = find_casework_rows(md_df)
 
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30600', '', 'I added to case', '', 'Casework'],
-                    ['30601', '', 'Already opened a case', '', 'Casework'],
-                    ['30602', '', 'CASE CLOSED', '', 'Casework'],
-                    ['30603', '', 'Case for doe', '', 'Casework'],
-                    ['30604', '', 'A case has been opened', '', 'Casework'],
-                    ['30605', '', 'Maybe case issue', '', 'Casework'],
-                    ['30606', '', 'case work', '', 'Casework'],
-                    ['30607', '', 'For casework', '', 'Casework'],
-                    ['30607', '', 'For casewrk', '', 'Casework'],
-                    ['30608', 'Closed Case', '', '', 'Casework'],
-                    ['30609', 'Open Case', '', '', 'Casework'],
-                    ['30610', '', 'Mary started case yesterday', 'Admin', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', '', '', '', '', '', 'I added to case', '', '', 'Casework'],
+                    ['30601', '', '', '', '', '', 'Already opened a case', '', '', 'Casework'],
+                    ['30602', '', '', '', '', '', 'CASE CLOSED', '', '', 'Casework'],
+                    ['30603', '', '', '', '', '', 'Case for doe', '', '', 'Casework'],
+                    ['30604', '', '', '', '', '', 'A case has been opened', '', '', 'Casework'],
+                    ['30605', '', '', '', '', '', 'Maybe case issue', '', '', 'Casework'],
+                    ['30606', '', '', '', '', '', 'case work', '', '', 'Casework'],
+                    ['30607', '', '', '', '', '', 'For casework', '', '', 'Casework'],
+                    ['30607', '', '', '', '', '', 'For casewrk', '', '', 'Casework'],
+                    ['30608', 'Closed Case', '', '', '', '', '', '', '', 'Casework'],
+                    ['30609', 'Open Case', '', '', '', '', '', '', '', 'Casework'],
+                    ['30610', '', '', '', '', 'Admin', 'Mary started case yesterday', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
-        expected = [['zip', 'in_topic', 'out_text', 'out_topic', 'Appraisal_Category'],
-                    ['30611', 'Roads', 'Not a case', '', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30611', 'Roads', '', '', '', '', 'Not a case', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for phrase, df_casework_check")
 
 

--- a/tests/css_archiving_format/test_find_job_rows.py
+++ b/tests/css_archiving_format/test_find_job_rows.py
@@ -14,242 +14,244 @@ class MyTestCase(unittest.TestCase):
     def test_all(self):
         """Test for when all patterns indicating job applications are present"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Resume', 'job request', r'..\doc\resume.txt', 'Resume', 'job request', ''],
-                              ['30601', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc'],
-                              ['30602', 'Intern', '', '', 'Resume', '', ''],
-                              ['30603', 'Resume', 'job request', '', '', '', ''],
-                              ['30604', '', 'Job Request', '', '', 'job request', ''],
-                              ['30605', 'Admin', 'job request', '', 'Resume', '', r'..\doc\resume.txt']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Resume', 'job request', r'..\doc\resume.txt', '', 'Resume',
+                               'job request', '', ''],
+                              ['30601', '', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc', ''],
+                              ['30602', 'Intern', '', '', '', 'Resume', '', '', ''],
+                              ['30603', 'Resume', 'job request', '', '', '', '', '', ''],
+                              ['30604', '', 'Job Request', '', '', '', 'job request', '', ''],
+                              ['30605', 'Admin', 'job request', '', '', 'Resume', '', r'..\doc\resume.txt', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30602', 'Intern', '', '', 'Resume', '', '', 'Job_Application'],
-                    ['30601', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc',
-                     'Job_Application'],
-                    ['30600', 'Resume', 'job request', r'..\doc\resume.txt', 'Resume', 'job request', '',
-                     'Job_Application'],
-                    ['30603', 'Resume', 'job request', '', '', '', '', 'Job_Application'],
-                    ['30604', '', 'Job Request', '', '', 'job request', '', 'Job_Application'],
-                    ['30605', 'Admin', 'job request', '', 'Resume', '', r'..\doc\resume.txt', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30602', 'Intern', '', '', '', 'Resume', '', '', '', 'Job_Application'],
+                    ['30601', '', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc',
+                     '', 'Job_Application'],
+                    ['30600', 'Resume', 'job request', r'..\doc\resume.txt', '', 'Resume', 'job request', '',
+                     '', 'Job_Application'],
+                    ['30603', 'Resume', 'job request', '', '', '', '', '', '', 'Job_Application'],
+                    ['30604', '', 'Job Request', '', '', '', 'job request', '', '', 'Job_Application'],
+                    ['30605', 'Admin', 'job request', '', '', 'Resume', '', r'..\doc\resume.txt', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_job_check")
 
     def test_in_document_name(self):
         """Test for when column in_document_name contains a word or phrase indicating job applications
         (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', ''],
-                              ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', ''],
-                              ['30602', 'Admin', '', r'..\doc\resume.txt', 'Admin', 'Files', ''],
-                              ['30603', '', '', '', '', 'Note', ''],
-                              ['30604', '', '', r'..\doc\jobs\file.doc', '', 'Note', ''],
-                              ['30605', '', '', r'..\doc\jobs\Resume_Regret.doc', '', 'Note', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text',
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', '', '', ''],
+                              ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', '', '', ''],
+                              ['30602', 'Admin', '', r'..\doc\resume.txt', '', 'Admin', 'Files', '', ''],
+                              ['30603', '', '', '', '', '', 'Note', '', ''],
+                              ['30604', '', '', r'..\doc\jobs\file.doc', '', '', 'Note', '', ''],
+                              ['30605', '', '', r'..\doc\jobs\Resume_Regret.doc', '', '', 'Note', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', '', 'Job_Application'],
-                    ['30602', 'Admin', '', r'..\doc\resume.txt', 'Admin', 'Files', '', 'Job_Application'],
-                    ['30605', '', '', r'..\doc\jobs\Resume_Regret.doc', '', 'Note', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', '', '', '', 'Job_Application'],
+                    ['30602', 'Admin', '', r'..\doc\resume.txt', '', 'Admin', 'Files', '', '', 'Job_Application'],
+                    ['30605', '', '', r'..\doc\jobs\Resume_Regret.doc', '', '', 'Note', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', '', 'Job_Application'],
-                    ['30604', '', '', r'..\doc\jobs\file.doc', '', 'Note', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', '', '', '', 'Job_Application'],
+                    ['30604', '', '', r'..\doc\jobs\file.doc', '', '', 'Note', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
 
     def test_in_text(self):
         """Test for when column in_text contains a word or phrase indicating job applications (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Gen', ' new job request', '', 'Gen', 'info sent', ''],
-                              ['30601', 'Admin', 'job requested', '', 'Admin', '', r'..\doc\response.doc'],
-                              ['30602', '', 'Job Request', '', '', '', ''],
-                              ['30603', 'Arts', 'Freelance job', '', '', '', ''],
-                              ['30604', '', 'note', '', '', '', ''],
-                              ['30605', '', 'resume', '', '', '', ''],
-                              ['30606', '', 'Forwarded Resume', '', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Gen', ' new job request', '', '', 'Gen', 'info sent', '', ''],
+                              ['30601', 'Admin', 'job requested', '', '', 'Admin', '', r'..\doc\response.doc', ''],
+                              ['30602', '', 'Job Request', '', '', '', '', '', ''],
+                              ['30603', 'Arts', 'Freelance job', '', '', '', '', '', ''],
+                              ['30604', '', 'note', '', '', '', '', '', ''],
+                              ['30605', '', 'resume', '', '', '', '', '', ''],
+                              ['30606', '', 'Forwarded Resume', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
         
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Gen', ' new job request', '', 'Gen', 'info sent', '', 'Job_Application'],
-                    ['30601', 'Admin', 'job requested', '', 'Admin', '', r'..\doc\response.doc', 'Job_Application'],
-                    ['30602', '', 'Job Request', '', '', '', '', 'Job_Application'],
-                    ['30605', '', 'resume', '', '', '', '', 'Job_Application'],
-                    ['30606', '', 'Forwarded Resume', '', '', '', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Gen', ' new job request', '', '', 'Gen', 'info sent', '', '', 'Job_Application'],
+                    ['30601', 'Admin', 'job requested', '', '', 'Admin', '', r'..\doc\response.doc', '',
+                     'Job_Application'],
+                    ['30602', '', 'Job Request', '', '', '', '', '', '', 'Job_Application'],
+                    ['30605', '', 'resume', '', '', '', '', '', '', 'Job_Application'],
+                    ['30606', '', 'Forwarded Resume', '', '', '', '', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30603', 'Arts', 'Freelance job', '', '', '', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', 'Arts', 'Freelance job', '', '', '', '', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_job_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains one of the topics indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Intern^General', '', '', '', '', ''],
-                              ['30601', 'Admin^Resumes', '', '', '', 'Note', ''],
-                              ['30602', 'Housing', '', '', 'Housing', '', ''],
-                              ['30603', 'Resumes', '', '', 'Economy', '', ''],
-                              ['30604', 'Intern', '', '', '', '', ''],
-                              ['30605', 'Job Hunting', '', '', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Intern^General', '', '', '', '', '', '', ''],
+                              ['30601', 'Admin^Resumes', '', '', '', '', 'Note', '', ''],
+                              ['30602', 'Housing', '', '', '', 'Housing', '', '', ''],
+                              ['30603', 'Resumes', '', '', '', 'Economy', '', '', ''],
+                              ['30604', 'Intern', '', '', '', '', '', '', ''],
+                              ['30605', 'Job Hunting', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Intern^General', '', '', '', '', '', 'Job_Application'],
-                    ['30601', 'Admin^Resumes', '', '', '', 'Note', '', 'Job_Application'],
-                    ['30603', 'Resumes', '', '', 'Economy', '', '', 'Job_Application'],
-                    ['30604', 'Intern', '', '', '', '', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Intern^General', '', '', '', '', '', '', '', 'Job_Application'],
+                    ['30601', 'Admin^Resumes', '', '', '', '', 'Note', '', '', 'Job_Application'],
+                    ['30603', 'Resumes', '', '', '', 'Economy', '', '', '', 'Job_Application'],
+                    ['30604', 'Intern', '', '', '', '', '', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30605', 'Job Hunting', '', '', '', '', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30605', 'Job Hunting', '', '', '', '', '', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_job_check")
 
     def test_none(self):
         """Test for when no patterns indicating job applications are present"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Farms', '', '', '', 'Note', ''],
-                              ['30601', 'Cats', '', '', 'Cats', '', ''],
-                              ['30602', 'Economy', '', '', 'Econ Plan', '', r'..\doc\econ-outlook.doc']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Farms', '', '', '', '', 'Note', '', ''],
+                              ['30601', 'Cats', '', '', '', 'Cats', '', '', ''],
+                              ['30602', 'Economy', '', '', '', 'Econ Plan', '', r'..\doc\econ-outlook.doc', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_job_check")
 
     def test_out_document_name(self):
         """Test for when column out_document_name contains a word or phrase indicating job applications 
         (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Admin', '', '', '', '', r'..\doc\Doe Job Interview.txt'],
-                              ['30601', 'Arts', '', '', '', '', r'..\doc\job_file.txt'],
-                              ['30602', 'Admin', '', '', 'Admin', 'Files', r'..\doc\resume.txt'],
-                              ['30603', '', '', '', '', 'Note', ''],
-                              ['30604', '', '', '', '', 'Note', r'..\doc\jobs\file.doc'],
-                              ['30605', '', '', '', '', 'Note', r'..\doc\jobs\Resume_Regret.doc']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Admin', '', '', '', '', '', r'..\doc\Doe Job Interview.txt', ''],
+                              ['30601', 'Arts', '', '', '', '', '', r'..\doc\job_file.txt', ''],
+                              ['30602', 'Admin', '', '', '', 'Admin', 'Files', r'..\doc\resume.txt', ''],
+                              ['30603', '', '', '', '', '', 'Note', '', ''],
+                              ['30604', '', '', '', '', '', 'Note', r'..\doc\jobs\file.doc', ''],
+                              ['30605', '', '', '', '', '', 'Note', r'..\doc\jobs\Resume_Regret.doc', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Admin', '', '', '', '', r'..\doc\Doe Job Interview.txt', 'Job_Application'],
-                    ['30602', 'Admin', '', '', 'Admin', 'Files', r'..\doc\resume.txt', 'Job_Application'],
-                    ['30605', '', '', '', '', 'Note', r'..\doc\jobs\Resume_Regret.doc', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Admin', '', '', '', '', '', r'..\doc\Doe Job Interview.txt', '', 'Job_Application'],
+                    ['30602', 'Admin', '', '', '', 'Admin', 'Files', r'..\doc\resume.txt', '', 'Job_Application'],
+                    ['30605', '', '', '', '', '', 'Note', r'..\doc\jobs\Resume_Regret.doc', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30601', 'Arts', '', '', '', '', r'..\doc\job_file.txt', 'Job_Application'],
-                    ['30604', '', '', '', '', 'Note', r'..\doc\jobs\file.doc', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'Arts', '', '', '', '', '', r'..\doc\job_file.txt', '', 'Job_Application'],
+                    ['30604', '', '', '', '', '', 'Note', r'..\doc\jobs\file.doc', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
 
     def test_out_text(self):
         """Test for when column out_text contains a word or phrase indicating job applications (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Farms', '', '', 'Agriculture', 'Job numbers', ''],
-                              ['30601', 'Admin', '', '', 'Admin', 'District Job Request', ''],
-                              ['30602', '', '', '', 'Economy', '', 'Jobs report'],
-                              ['30603', '', '', '', '', 'job request', ''],
-                              ['30604', 'Admin', '', '', '', 'job request - accept', ''],
-                              ['30605', 'Admin', '', '', '', 'Doe resume', ''],
-                              ['30606', 'Admin', '', '', '', 'RESUME', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', 'Farms', '', '', '', 'Agriculture', 'Job numbers', '', ''],
+                              ['30601', 'Admin', '', '', '', 'Admin', 'District Job Request', '', ''],
+                              ['30602', '', '', '', '', 'Economy', '', 'Jobs report', ''],
+                              ['30603', '', '', '', '', '', 'job request', '', ''],
+                              ['30604', 'Admin', '', '', '', '', 'job request - accept', '', ''],
+                              ['30605', 'Admin', '', '', '', '', 'Doe resume', '', ''],
+                              ['30606', 'Admin', '', '', '', '', 'RESUME', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30601', 'Admin', '', '', 'Admin', 'District Job Request', '', 'Job_Application'],
-                    ['30603', '', '', '', '', 'job request', '', 'Job_Application'],
-                    ['30604', 'Admin', '', '', '', 'job request - accept', '', 'Job_Application'],
-                    ['30605', 'Admin', '', '', '', 'Doe resume', '', 'Job_Application'],
-                    ['30606', 'Admin', '', '', '', 'RESUME', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'Admin', '', '', '', 'Admin', 'District Job Request', '', '', 'Job_Application'],
+                    ['30603', '', '', '', '', '', 'job request', '', '', 'Job_Application'],
+                    ['30604', 'Admin', '', '', '', '', 'job request - accept', '', '', 'Job_Application'],
+                    ['30605', 'Admin', '', '', '', '', 'Doe resume', '', '', 'Job_Application'],
+                    ['30606', 'Admin', '', '', '', '', 'RESUME', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30600', 'Farms', '', '', 'Agriculture', 'Job numbers', '', 'Job_Application'],
-                    ['30602', '', '', '', 'Economy', '', 'Jobs report', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Farms', '', '', '', 'Agriculture', 'Job numbers', '', '', 'Job_Application'],
+                    ['30602', '', '', '', '', 'Economy', '', 'Jobs report', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_job_check")
 
     def test_out_topic(self):
         """"Test for when column out_topic contains one of the topics indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', '', '', '', 'Economy', 'text', r'..\doc\form\econ.doc'],
-                              ['30601', '', '', '', 'Gen^Resumes', '', ''],
-                              ['30602', '', '', '', 'Intern', '', ''],
-                              ['30603', '', '', '', 'Intern^Admin', 'note', ''],
-                              ['30604', '', '', '', 'Water', '', ''],
-                              ['30605', '', '', '', 'Resumes', 'note', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 
-                                      'out_document_name'])
+        md_df = pd.DataFrame([['30600', '', '', '', '', 'Economy', 'text', r'..\doc\form\econ.doc', ''],
+                              ['30601', '', '', '', '', 'Gen^Resumes', '', '', ''],
+                              ['30602', '', '', '', '', 'Intern', '', '', ''],
+                              ['30603', '', '', '', '', 'Intern^Admin', 'note', '', ''],
+                              ['30604', '', '', '', '', 'Water', '', '', ''],
+                              ['30605', '', '', '', '', 'Resumes', 'note', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_job, df_job_check = find_job_rows(md_df)
 
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category'],
-                    ['30601', '', '', '', 'Gen^Resumes', '', '', 'Job_Application'],
-                    ['30602', '', '', '', 'Intern', '', '', 'Job_Application'],
-                    ['30603', '', '', '', 'Intern^Admin', 'note', '', 'Job_Application'],
-                    ['30605', '', '', '', 'Resumes', 'note', '', 'Job_Application']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', '', '', '', '', 'Gen^Resumes', '', '', '', 'Job_Application'],
+                    ['30602', '', '', '', '', 'Intern', '', '', '', 'Job_Application'],
+                    ['30603', '', '', '', '', 'Intern^Admin', 'note', '', '', 'Job_Application'],
+                    ['30605', '', '', '', '', 'Resumes', 'note', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
-        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'out_topic', 'out_text', 'out_document_name',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text', 
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_job_check")
 
         

--- a/tests/css_archiving_format/test_find_recommendation_rows.py
+++ b/tests/css_archiving_format/test_find_recommendation_rows.py
@@ -14,152 +14,182 @@ class MyTestCase(unittest.TestCase):
     def test_all(self):
         """Test for when all patterns indicating recommendations are present"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Recommendations^General', '', 'Recommendations', ''],
-                              ['30601', '', 'rec for john doe', '', 'policy for recommendations sent'],
-                              ['30602', 'Recommendations', 'letter of recommendation for smith', '', ''],
-                              ['30603', 'Recommendations', 'rec for green', 'Recommendations', 'wrote recommendation'],
-                              ['30604', '', '', 'Admin^Recommendations', 'wrote recommendation']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Recommendations^General', 'my recommendation', '', '', 'Recommendations',
+                               '', '', ''],
+                              ['30601', '', 'rec for john doe', '', '', '', 'policy for recommendations sent', '', ''],
+                              ['30602', 'Recommendations', 'letter of recommendation for smith', '', '', '', '', '',
+                               'decline_recommendation'],
+                              ['30603', 'Recommendations', 'rec for green', '', '', 'Recommendations',
+                               'wrote recommendation', '', ''],
+                              ['30604', '', '', '', '', 'Admin^Recommendations', 'wrote recommendation', '', ''],
+                              ['30605', 'Admin', 'my recommendation is x', '', '', 'Admin', '', '', ''],
+                              ['30606', 'Admin', 'note', '', '', 'Admin', 'recommendation', r'doc\recommendation.txt',
+                               'name_date']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Recommendations^General', '', 'Recommendations', '', 'Recommendation'],
-                    ['30602', 'Recommendations', 'letter of recommendation for smith', '', '', 'Recommendation'],
-                    ['30603', 'Recommendations', 'rec for green', 'Recommendations', 'wrote recommendation',
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Recommendations^General', 'my recommendation', '', '', 'Recommendations', '', '', '',
                      'Recommendation'],
-                    ['30604', '', '', 'Admin^Recommendations', 'wrote recommendation', 'Recommendation'],
-                    ['30601', '', 'rec for john doe', '', 'policy for recommendations sent', 'Recommendation']]
+                    ['30602', 'Recommendations', 'letter of recommendation for smith', '', '', '', '', '',
+                     'decline_recommendation', 'Recommendation'],
+                    ['30603', 'Recommendations', 'rec for green', '', '', 'Recommendations', 'wrote recommendation',
+                     '', '', 'Recommendation'],
+                    ['30604', '', '', '', '', 'Admin^Recommendations', 'wrote recommendation', '', '', 'Recommendation'],
+                    ['30601', '', 'rec for john doe', '', '', '', 'policy for recommendations sent', '', '',
+                     'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30605', 'Admin', 'my recommendation is x', '', '', 'Admin', '', '', '', 'Recommendation'],
+                    ['30606', 'Admin', 'note', '', '', 'Admin', 'recommendation', r'doc\recommendation.txt',
+                     'name_date', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_recommendations_check")
 
     def test_in_text(self):
         """Test for when column in_text contains a phrase indicating recommendations (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Admin', 'Senator wrote recommendation', '', ''],
-                              ['30601', 'Admin', 'policy for recommendations sent', 'Admin', ''],
-                              ['30602', 'Arts', 'Program recommendation', '', ''],
-                              ['30603', 'General', 'Letter of Recommendation', '', ''],
-                              ['30604', '', 'Requested rec for JD', '', ''],
-                              ['30605', 'Water', '', '', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Admin', 'Senator wrote recommendation', '', '', '', '', '', ''],
+                              ['30601', 'Admin', 'policy for recommendations sent', '', '', 'Admin', '', '', ''],
+                              ['30602', 'Arts', 'Program recommendation', '', '', '', '', '', ''],
+                              ['30603', 'General', 'Letter of Recommendation', '', '', '', '', '', ''],
+                              ['30604', '', 'Requested rec for JD', '', '', '', '', '', ''],
+                              ['30605', 'Water', '', '', '', '', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Admin', 'Senator wrote recommendation', '', '', 'Recommendation'],
-                    ['30601', 'Admin', 'policy for recommendations sent', 'Admin', '', 'Recommendation'],
-                    ['30603', 'General', 'Letter of Recommendation', '', '', 'Recommendation'],
-                    ['30604', '', 'Requested rec for JD', '', '', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Admin', 'Senator wrote recommendation', '', '', '', '', '', '', 'Recommendation'],
+                    ['30601', 'Admin', 'policy for recommendations sent', '', '', 'Admin', '', '', '', 'Recommendation'],
+                    ['30603', 'General', 'Letter of Recommendation', '', '', '', '', '', '', 'Recommendation'],
+                    ['30604', '', 'Requested rec for JD', '', '', '', '', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30602', 'Arts', 'Program recommendation', '', '', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30602', 'Arts', 'Program recommendation', '', '', '', '', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_text, df_recommendations_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains Recommendations"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Recommendations', 'note', '', ''],
-                              ['30601', 'Admin^Recommendations', '', '', ''],
-                              ['30602', 'Recommendations^Admin', '', '', ''],
-                              ['30603', 'Policy Recommendation', '', 'Water', 'Reply note'],
-                              ['30604', '', '', 'Gen', '']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Recommendations', 'note', '', '', '', '', '', ''],
+                              ['30601', 'Admin^Recommendations', '', '', '', '', '', '', ''],
+                              ['30602', 'Recommendations^Admin', '', '', '', '', '', '', ''],
+                              ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', ''],
+                              ['30604', '', '', '', '', 'Gen', '', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Recommendations', 'note', '', '', 'Recommendation'],
-                    ['30601', 'Admin^Recommendations', '', '', '', 'Recommendation'],
-                    ['30602', 'Recommendations^Admin', '', '', '', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Recommendations', 'note', '', '', '', '', '', '', 'Recommendation'],
+                    ['30601', 'Admin^Recommendations', '', '', '', '', '', '', '', 'Recommendation'],
+                    ['30602', 'Recommendations^Admin', '', '', '', '', '', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30603', 'Policy Recommendation', '', 'Water', 'Reply note', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations_check")
 
     def test_none(self):
         """Test for when no patterns indicating recommendations are present"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Farm', '', 'Animals', ''],
-                              ['30601', 'Water', 'note', 'Rights', 'note']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Farm', '', 'Animals', '', '', ''],
+                              ['30601', 'Water', 'note', '', '', 'Rights', 'note', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_recommendations_check")
 
     def test_out_text(self):
         """Test for when column out_text contains a phrase indicating recommendations (case-insensitive)"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Admin', 'note', '', 'Doe letter of recommendation'],
-                              ['30601', 'Admin', 'note', '', 'Policy for recommendations sent'],
-                              ['30602', 'Admin', 'note', '', 'REC FOR JD'],
-                              ['30603', 'Admin', '', '', 'not a recommendation'],
-                              ['30604', 'Admin', '', '', 'recommendation to support'],
-                              ['30605', 'Admin', '', '', 'Wrote Recommendation']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', 'Admin', 'note', '', '', '', 'Doe letter of recommendation', '', ''],
+                              ['30601', 'Admin', 'note', '', '', '', 'Policy for recommendations sent', '', ''],
+                              ['30602', 'Admin', 'note', '', '', '', 'REC FOR JD', '', ''],
+                              ['30603', 'Admin', '', '', '', '', 'not a recommendation', '', ''],
+                              ['30604', 'Admin', '', '', '', '', 'recommendation to support', '', ''],
+                              ['30605', 'Admin', '', '', '', '', 'Wrote Recommendation', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', 'Admin', 'note', '', 'Doe letter of recommendation', 'Recommendation'],
-                    ['30601', 'Admin', 'note', '', 'Policy for recommendations sent', 'Recommendation'],
-                    ['30602', 'Admin', 'note', '', 'REC FOR JD', 'Recommendation'],
-                    ['30605', 'Admin', '', '', 'Wrote Recommendation', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', 'Admin', 'note', '', '', '', 'Doe letter of recommendation', '', '', 'Recommendation'],
+                    ['30601', 'Admin', 'note', '', '', '', 'Policy for recommendations sent', '', '', 'Recommendation'],
+                    ['30602', 'Admin', 'note', '', '', '', 'REC FOR JD', '', '', 'Recommendation'],
+                    ['30605', 'Admin', '', '', '', '', 'Wrote Recommendation', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30603', 'Admin', '', '', 'not a recommendation', 'Recommendation'],
-                    ['30604', 'Admin', '', '', 'recommendation to support', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30603', 'Admin', '', '', '', '', 'not a recommendation', '', '', 'Recommendation'],
+                    ['30604', 'Admin', '', '', '', '', 'recommendation to support', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for out_text, df_recommendations_check")
 
     def test_out_topic(self):
         """Test for when column out_topic contains Recommendations"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', '', '', 'Water', 'Policy Recommendation'],
-                              ['30601', 'General', '', 'General^Recommendations', ''],
-                              ['30602', 'Water', '', '', 'Recommendation'],
-                              ['30603', '', 'note', 'Recommendations', ''],
-                              ['30604', 'Admin', '', 'Recommendations^Admin', 'note']],
-                             columns=['zip', 'in_topic', 'in_text', 'out_topic', 'out_text'])
+        md_df = pd.DataFrame([['30600', '', '', '', '', 'Water', 'Policy Recommendation', '', ''],
+                              ['30601', 'General', '', '', '', 'General^Recommendations', '', '', ''],
+                              ['30602', 'Water', '', '', '', '', 'Recommendation', '', ''],
+                              ['30603', '', 'note', '', '', 'Recommendations', '', '', ''],
+                              ['30604', 'Admin', '', '', '', 'Recommendations^Admin', 'note', '', '']],
+                             columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                      'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_recommendations, df_recommendations_check = find_recommendation_rows(md_df)
 
         # Tests the values in df_recommendations are correct.
         result = df_to_list(df_recommendations)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30601', 'General', '', 'General^Recommendations', '', 'Recommendation'],
-                    ['30603', '', 'note', 'Recommendations', '', 'Recommendation'],
-                    ['30604', 'Admin', '', 'Recommendations^Admin', 'note', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', 'General', '', '', '', 'General^Recommendations', '', '', '', 'Recommendation'],
+                    ['30603', '', 'note', '', '', 'Recommendations', '', '', '', 'Recommendation'],
+                    ['30604', 'Admin', '', '', '', 'Recommendations^Admin', 'note', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
-        expected = [['zip', 'in_topic', 'in_text', 'out_topic', 'out_text', 'Appraisal_Category'],
-                    ['30600', '', '', 'Water', 'Policy Recommendation', 'Recommendation'],
-                    ['30602', 'Water', '', '', 'Recommendation', 'Recommendation']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30600', '', '', '', '', 'Water', 'Policy Recommendation', '', '', 'Recommendation'],
+                    ['30602', 'Water', '', '', '', '', 'Recommendation', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_recommendations_check")
 
 


### PR DESCRIPTION
Check specific columns for the keyword that should be checked for additional appraisal, rather than checking all columns. Using all columns was resulting in a lot of false positives to sort through (e.g., last names and city names) which are not relevant for determining appraisal decisions.