### PR TITLE
CSS archiving and dif sync

### DIFF
--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -24,15 +24,17 @@ def appraisal_check_df(df, keyword, category):
     likely to indicate appraisal is needed, with a new column for the appraisal category"""
 
     # Makes a series for each column with if each row contain the keyword (case-insensitive), excluding blanks.
+    in_topic = df['in_topic'].str.contains(keyword, case=False, na=False)
     in_doc = df['in_document_name'].str.contains(keyword, case=False, na=False)
     in_fillin = df['in_fillin'].str.contains(keyword, case=False, na=False)
     in_text = df['in_text'].str.contains(keyword, case=False, na=False)
+    out_topic = df['out_topic'].str.contains(keyword, case=False, na=False)
     out_doc = df['out_document_name'].str.contains(keyword, case=False, na=False)
     out_fillin = df['out_fillin'].str.contains(keyword, case=False, na=False)
     out_text = df['out_text'].str.contains(keyword, case=False, na=False)
 
     # Makes a dataframe with all rows containing the keyword in at least one of the columns.
-    df_check = df[in_doc | in_fillin | in_text | out_doc | out_fillin | out_text].copy()
+    df_check = df[in_topic | in_doc | in_fillin | in_text | out_topic | out_doc | out_fillin | out_text].copy()
 
     # Adds a column with the appraisal category.
     df_check['Appraisal_Category'] = category
@@ -337,9 +339,7 @@ def find_academy_rows(df):
 
     # Makes another dataframe with rows containing "academy" to check for new patterns that could
     # indicate academy applications.
-    check = np.column_stack([df[col].str.contains('academy', case=False, na=False) for col in df])
-    df_academy_check = df.loc[check.any(axis=1)].copy()
-    df_academy_check['Appraisal_Category'] = 'Academy_Application'
+    df_academy_check = appraisal_check_df(df, 'academy', 'Academy_Application')
 
     return df_academy, df_academy_check
 
@@ -405,9 +405,7 @@ def find_casework_rows(df):
     df_casework['Appraisal_Category'] = "Casework"
 
     # Makes another dataframe with rows containing "case" to check for new patterns that could indicate casework.
-    check = np.column_stack([df[col].str.contains('case', case=False, na=False) for col in df])
-    df_casework_check = df.loc[check.any(axis=1)].copy()
-    df_casework_check['Appraisal_Category'] = 'Casework'
+    df_casework_check = appraisal_check_df(df, 'case', 'Casework')
 
     return df_casework, df_casework_check
 
@@ -456,9 +454,7 @@ def find_job_rows(df):
     df_job['Appraisal_Category'] = 'Job_Application'
 
     # Makes another dataframe with rows containing "job" to check for new patterns that could indicate job applications.
-    check = np.column_stack([df[col].str.contains('job', case=False, na=False) for col in df])
-    df_job_check = df.loc[check.any(axis=1)].copy()
-    df_job_check['Appraisal_Category'] = 'Job_Application'
+    df_job_check = appraisal_check_df(df, 'job', 'Job_Application')
 
     return df_job, df_job_check
 
@@ -495,9 +491,7 @@ def find_recommendation_rows(df):
 
     # Makes another dataframe with rows containing "recommendation" to check for new patterns that could
     # indicate recommendations.
-    check = np.column_stack([df[col].str.contains('recommendation', case=False, na=False) for col in df])
-    df_recommendation_check = df.loc[check.any(axis=1)].copy()
-    df_recommendation_check['Appraisal_Category'] = 'Recommendation'
+    df_recommendation_check = appraisal_check_df(df, 'recommendation', 'Recommendation')
 
     return df_recommendation, df_recommendation_check
 

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -311,12 +311,12 @@ def find_academy_rows(df):
 
     # Column in_topic includes one or more of the topics that indicate academy applications.
     topics_list = ['Academy Applicant', 'Military Service Academy']
-    in_topic = df['in_topic'].str.contains('|'.join(topics_list), na=False)
+    in_topic = df['in_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
 
     # Column out_topic includes one or more of the topics that indicate academy applications.
-    out_topic = df['out_topic'].str.contains('|'.join(topics_list), na=False)
+    out_topic = df['out_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
@@ -377,12 +377,12 @@ def find_casework_rows(df):
 
     # Column in_topic includes one or more of the topics that indicate casework.
     topics_list = ['Casework', 'Casework Issues', 'Prison Case']
-    in_topic = df['in_topic'].str.contains('|'.join(topics_list), na=False)
+    in_topic = df['in_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
 
     # Column out_topic includes one or more of the topics that indicate casework.
-    out_topic = df['out_topic'].str.contains('|'.join(topics_list), na=False)
+    out_topic = df['out_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
@@ -418,12 +418,12 @@ def find_job_rows(df):
 
     # Column in_topic includes one or more of the topics that indicate job applications.
     topics_list = ['Intern', 'Resumes']
-    in_topic = df['in_topic'].str.contains('|'.join(topics_list), na=False)
+    in_topic = df['in_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
 
     # Column out_topic includes one or more of the topics that indicate job applications.
-    out_topic = df['out_topic'].str.contains('|'.join(topics_list), na=False)
+    out_topic = df['out_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
@@ -451,7 +451,8 @@ def find_job_rows(df):
 
     # Makes a single dataframe with all rows that indicate job applications
     # and adds a column for the appraisal category (needed for the file deletion log).
-    df_job = pd.concat([df_in_topic, df_out_topic, df_in_text, df_out_text, df_in_doc, df_out_doc], axis=0, ignore_index=True)
+    df_job = pd.concat([df_in_topic, df_out_topic, df_in_text, df_out_text, df_in_doc, df_out_doc],
+                       axis=0, ignore_index=True)
     df_job['Appraisal_Category'] = 'Job_Application'
 
     # Makes another dataframe with rows containing "job" to check for new patterns that could indicate job applications.
@@ -467,12 +468,12 @@ def find_recommendation_rows(df):
     Once a row matches one pattern, it is not considered for other patterns."""
 
     # Column in_topic includes Recommendations.
-    in_topic = df['in_topic'].str.contains('Recommendations', na=False)
+    in_topic = df['in_topic'].str.contains('Recommendations', case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
 
     # Column out_topic includes Recommendations.
-    out_topic = df['out_topic'].str.contains('Recommendations', na=False)
+    out_topic = df['out_topic'].str.contains('Recommendations', case=False, na=False)
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -234,12 +234,12 @@ def check_metadata_usability(df, output_dir):
     columns_df.to_csv(os.path.join(output_dir, 'usability_report_metadata.csv'), index=True, index_label='Column_Name')
 
 
-def delete_appraisal_letters(input_dir, df_appraisal):
+def delete_appraisal_letters(input_dir, output_dir, df_appraisal):
     """Deletes letters received from constituents and individual letters sent back by the office
     because they are one of the types of letters not retained for appraisal reasons"""
 
     # Creates a file deletion log, with a header row.
-    log_path = os.path.join(os.path.dirname(input_dir), f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv")
+    log_path = os.path.join(output_dir, f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv")
     file_deletion_log(log_path, None, 'header')
 
     # For every row in df_appraisal, deletes any letter in the in_document_name and out_document_name columns.
@@ -655,7 +655,7 @@ if __name__ == '__main__':
     elif script_mode == 'appraisal':
         print("\nThe script is running in appraisal mode.")
         print("It will delete letters due to appraisal but not change the metadata file.")
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
     # TODO For preservation, prepares the export for the general_aip.py script.
     # Run in appraisal mode first to remove letters.

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -152,7 +152,13 @@ def check_metadata_formatting(column, df, output_dir):
                 'zip': r'^\d{5}(-\d{4})?(-X{4})?$'}
 
     # Makes a dataframe with all rows that do not match the expected formatting, excluding blanks.
-    match = df[column].str.contains(patterns[column], regex=True, na=False)
+    # If the column is missing from the dataframe or blank, it returns default text instead of a row count.
+    try:
+        match = df[column].str.contains(patterns[column], regex=True, na=False)
+    except KeyError:
+        return 'column_missing'
+    except AttributeError:
+        return 'column_blank'
     df_no_match = df[~match & df[column].notna()]
 
     # Saves the dataframe to a csv if there were any that did not match the expected formatting.
@@ -169,9 +175,15 @@ def check_metadata_formatting_multi(column, df, output_dir):
     and save the rows to a csv"""
 
     # Makes a dataframe with all rows that do not match any of the expected formatting, excluding blanks.
-    match_blob = df[column].str.contains(r'^..\\documents\\BlobExport\\', regex=True, na=False)
-    match_dos = df[column].str.contains(r'^\\\\[a-z]+-[a-z]+\\dos\\public', regex=True, na=False)
-    match_e = df[column].str.contains(r'^e:\\emailobj', regex=True, na=False)
+    # If the column is missing from the dataframe or blank, it returns default text instead of a row count.
+    try:
+        match_blob = df[column].str.contains(r'^..\\documents\\BlobExport\\', regex=True, na=False)
+        match_dos = df[column].str.contains(r'^\\\\[a-z]+-[a-z]+\\dos\\public', regex=True, na=False)
+        match_e = df[column].str.contains(r'^e:\\emailobj', regex=True, na=False)
+    except KeyError:
+        return 'column_missing'
+    except AttributeError:
+        return 'column_blank'
     df_no_match = df[~(match_blob | match_dos | match_e) & df[column].notna()]
 
     # Saves the dataframe to a csv if there were any that did not match the expected formatting.

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -543,10 +543,14 @@ def remove_pii(df):
 def split_congress_year(df, output_dir):
     """Make one CSV per Congress Year"""
 
+    # Makes a folder for all the CSVs.
+    cy_dir = os.path.join(output_dir, 'archiving_correspondence_by_congress_year')
+    os.mkdir(cy_dir)
+
     # Saves rows without a year (date is a not a number, could be blank or text) to a CSV, if any.
     df_undated = df[pd.to_numeric(df['in_date'], errors='coerce').isnull()]
     if len(df_undated.index) > 0:
-        df_undated.to_csv(os.path.join(output_dir, 'undated.csv'), index=False)
+        df_undated.to_csv(os.path.join(cy_dir, 'undated.csv'), index=False)
 
     # Removes rows without a year from the dataframe, so the rest can be split by Congress Year.
     df = df[pd.to_numeric(df['in_date'], errors='coerce').notnull()].copy()
@@ -565,7 +569,7 @@ def split_congress_year(df, output_dir):
     # The year and congress_year columns are first removed, so the CSV only has the original columns.
     for congress_year, cy_df in df.groupby('congress_year'):
         cy_df = cy_df.drop(['year', 'congress_year'], axis=1)
-        cy_df.to_csv(os.path.join(output_dir, f'{congress_year}.csv'), index=False)
+        cy_df.to_csv(os.path.join(cy_dir, f'{congress_year}.csv'), index=False)
 
 
 def topics_report(df, output_dir):

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -247,8 +247,8 @@ def delete_appraisal_letters(input_dir, output_dir, df_appraisal):
     # Form letters are retained.
     df_appraisal = df_appraisal.astype(str)
     for row in df_appraisal.itertuples():
-        if row.in_document_name != '' and row.in_document_name != 'nan':
-            name = row.in_document_name
+        name = row.in_document_name
+        if name != '' and name != 'nan':
             file_path = update_path(name, input_dir)
             if file_path == 'error_new':
                 file_deletion_log(log_path, name, 'Cannot determine file path: new path pattern in metadata')
@@ -260,8 +260,8 @@ def delete_appraisal_letters(input_dir, output_dir, df_appraisal):
                     file_deletion_log(log_path, file_path, 'Cannot delete: FileNotFoundError')
 
         # Deletes individual letters, not form letters, sent to constituents, if the "out" column isn't blank.
-        if row.out_document_name != '' and row.out_document_name != 'nan' and 'form' not in row.out_document_name:
-            name = row.out_document_name
+        name = row.out_document_name
+        if name != '' and name != 'nan' and 'form' not in name:
             file_path = update_path(name, input_dir)
             if file_path == 'error_new':
                 file_deletion_log(log_path, name, 'Cannot determine file path: new path pattern in metadata')

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -376,7 +376,7 @@ def find_casework_rows(df):
     Once a row matches one pattern, it is not considered for other patterns."""
 
     # Column in_topic includes one or more of the topics that indicate casework.
-    topics_list = ['Casework', 'Casework Issues', 'Prison Case']
+    topics_list = ['Casework', 'Prison Case']
     in_topic = df['in_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
@@ -415,7 +415,7 @@ def find_job_rows(df):
     Once a row matches one pattern, it is not considered for other patterns."""
 
     # Column in_topic includes one or more of the topics that indicate job applications.
-    topics_list = ['Intern', 'Resumes']
+    topics_list = ['Intern', 'Resume']
     in_topic = df['in_topic'].str.contains('|'.join(topics_list), case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
@@ -464,17 +464,17 @@ def find_recommendation_rows(df):
     Once a row matches one pattern, it is not considered for other patterns."""
 
     # Column in_topic includes Recommendations.
-    in_topic = df['in_topic'].str.contains('Recommendations', case=False, na=False)
+    in_topic = df['in_topic'].str.contains('Recommendation', case=False, na=False)
     df_in_topic = df[in_topic]
     df = df[~in_topic]
 
     # Column out_topic includes Recommendations.
-    out_topic = df['out_topic'].str.contains('Recommendations', case=False, na=False)
+    out_topic = df['out_topic'].str.contains('Recommendation', case=False, na=False)
     df_out_topic = df[out_topic]
     df = df[~out_topic]
 
     # Column in_text includes a phrase (case_insensitive) that indicates a recommendation.
-    phrase_list = ['Letter of recommendation', 'policy for recommendations', 'rec for', 'wrote recommendation']
+    phrase_list = ['Letter of recommendation', 'policy for recommendation', 'rec for', 'wrote recommendation']
     in_text = df['in_text'].str.contains('|'.join(phrase_list), case=False, na=False)
     df_in_text = df[in_text]
     df = df[~in_text]

--- a/css_data_interchange_format.py
+++ b/css_data_interchange_format.py
@@ -206,12 +206,12 @@ def check_metadata_usability(df, output_dir):
     columns_df.to_csv(os.path.join(output_dir, 'usability_report_metadata.csv'), index=True, index_label='Column_Name')
 
 
-def delete_appraisal_letters(input_dir, df_appraisal):
+def delete_appraisal_letters(input_dir, output_dir, df_appraisal):
     """Deletes letters received from constituents and individual letters sent back by the office
     because they are one of the types of letters not retained for appraisal reasons"""
 
     # Creates a file deletion log, with a header row.
-    log_path = os.path.join(os.path.dirname(input_dir), f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv")
+    log_path = os.path.join(output_dir, f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv")
     file_deletion_log(log_path, None, 'header')
 
     # For every row in df_appraisal, deletes any letter in the communication_document_name column except form letters.
@@ -547,7 +547,7 @@ if __name__ == '__main__':
     elif script_mode == 'appraisal':
         print("\nThe script is running in appraisal mode.")
         print("It will delete letters due to appraisal but not change the metadata file.")
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
     # TODO For preservation, prepares the export for the general_aip.py script.
     elif script_mode == 'preservation':

--- a/css_data_interchange_format.py
+++ b/css_data_interchange_format.py
@@ -98,7 +98,7 @@ def check_letter_matching(df, output_dir, input_dir):
     metadata_paths = doc_df['communication_document_name'].tolist()
 
     # Number of metadata rows without a file path.
-    blank_count = df['communication_document_name'].isna().sum()
+    blank_total = df['communication_document_name'].isna().sum()
 
     # Compares the list of file paths in the metadata to the export directory.
     metadata_only = list(set(metadata_paths) - set(input_dir_paths))
@@ -112,7 +112,7 @@ def check_letter_matching(df, output_dir, input_dir):
         report_writer.writerow(['Metadata_Only', len(metadata_only)])
         report_writer.writerow(['Directory_Only', len(directory_only)])
         report_writer.writerow(['Match', len(match)])
-        report_writer.writerow(['Metadata_Blank', blank_count])
+        report_writer.writerow(['Metadata_Blank', blank_total])
 
     # Saves the paths that did not match to a log.
     with open(os.path.join(output_dir, 'usability_report_matching_details.csv'), 'w', newline='') as report:

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -13,61 +13,61 @@ class MyTestCase(unittest.TestCase):
     def test_multiple_columns(self):
         """Test for when the keyword is in multiple columns per row"""
         # Makes a dataframe to use as test input and runs the function.
-        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
-                           ['30601', 'CASE', r'doc\Case_File.txt', '', '', r'form\a.txt', ''],
-                           ['30602', '', '', r'doc\file3.txt', 'Note', '', ''],
-                           ['30603', '', '', '', 'started case Tue', r'case\abc.txt', 'Mr._Case']],
-                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
-                                   'out_text', 'out_document_name', 'out_fillin'])
+        df = pd.DataFrame([['30600', '', 'note', r'doc\file1.txt', '', '', '', r'form\filea.txt', 'a_b'],
+                           ['30601', '', 'CASE', r'doc\Case_File.txt', '', '', '', r'form\a.txt', ''],
+                           ['30602', '', '', '', r'doc\file3.txt', '', 'Note', '', ''],
+                           ['30603', '', '', '', '', 'started case Tue', r'case\abc.txt', '', 'Mr._Case']],
+                          columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_check = appraisal_check_df(df, 'case', 'Casework')
 
         # Tests the values in df_check are correct.
         result = df_to_list(df_check)
-        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
-                     'Appraisal_Category'],
-                    ['30601', 'CASE', r'doc\Case_File.txt', '', '', r'form\a.txt', '', 'Casework'],
-                    ['30603', '', '', '', 'started case Tue', r'case\abc.txt', 'Mr._Case', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', '', 'CASE', r'doc\Case_File.txt', '', '', '', r'form\a.txt', '', 'Casework'],
+                    ['30603', '', '', '', '', 'started case Tue', r'case\abc.txt', '', 'Mr._Case', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one column")
 
     def test_one_column(self):
         """Test for when the keyword is in one column per row"""
         # Makes a dataframe to use as test input and runs the function.
-        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
-                           ['30601', 'CASE', '', '', '', r'form\a.txt', ''],
-                           ['30602', 'note', r'doc\Case_File.txt', '', '', '', ''],
-                           ['30603', '', '', '', 'started case Tue', '', 'a_b'],
-                           ['30604', 'note', r'doc\file2.txt', '', 'reply note', r'case\abc.txt', ''],
-                           ['30605', '', '', r'doc\file3.txt', 'Note', '', ''],
-                           ['30606', '', '', r'doc\file4.txt', 'Note', r'letter\123.txt', 'Mr._Case']],
-                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
-                                   'out_text', 'out_document_name', 'out_fillin'])
+        df = pd.DataFrame([['30600', '', 'note', r'doc\file1.txt', '', '', '', r'form\filea.txt', 'a_b'],
+                           ['30601', '', 'CASE', '', '', '', '', r'form\a.txt', ''],
+                           ['30602', '', 'note', r'doc\Case_File.txt', '', '', '', '', ''],
+                           ['30603', '', '', '', '', '', 'started case Tue', '', 'a_b'],
+                           ['30604', '', 'note', r'doc\file2.txt', '', '', 'reply note', r'case\abc.txt', ''],
+                           ['30605', '', '', '', r'doc\file3.txt', '', 'Note', '', ''],
+                           ['30606', '', '', '', r'doc\file4.txt', '', 'Note', r'letter\123.txt', 'Mr._Case']],
+                          columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_check = appraisal_check_df(df, 'case', 'Casework')
 
         # Tests the values in df_check are correct.
         result = df_to_list(df_check)
-        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
-                     'Appraisal_Category'],
-                    ['30601', 'CASE', '', '', '', r'form\a.txt', '', 'Casework'],
-                    ['30602', 'note', r'doc\Case_File.txt', '', '', '', '', 'Casework'],
-                    ['30603', '', '', '', 'started case Tue', '', 'a_b', 'Casework'],
-                    ['30604', 'note', r'doc\file2.txt', '', 'reply note', r'case\abc.txt', '', 'Casework'],
-                    ['30606', '', '', r'doc\file4.txt', 'Note', r'letter\123.txt', 'Mr._Case', 'Casework']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category'],
+                    ['30601', '', 'CASE', '', '', '', '', r'form\a.txt', '', 'Casework'],
+                    ['30602', '', 'note', r'doc\Case_File.txt', '', '', '', '', '', 'Casework'],
+                    ['30603', '', '', '', '', '', 'started case Tue', '', 'a_b', 'Casework'],
+                    ['30604', '', 'note', r'doc\file2.txt', '', '', 'reply note', r'case\abc.txt', '', 'Casework'],
+                    ['30606', '', '', '', r'doc\file4.txt', '', 'Note', r'letter\123.txt', 'Mr._Case', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for one column")
 
     def test_no_column(self):
         """Test for when the keyword is in no columns"""
         # Makes a dataframe to use as test input and runs the function.
-        df = pd.DataFrame([['30600', 'note', r'doc\file1.txt', '', '', r'form\filea.txt', 'a_b'],
-                           ['30602', 'note', '', '', '', r'form\a.txt', ''],
-                           ['30603', '', '', '', 'started Tue', '', 'a_b']],
-                          columns=['zip', 'in_text', 'in_document_name', 'in_fillin',
-                                   'out_text', 'out_document_name', 'out_fillin'])
+        df = pd.DataFrame([['30600', '', 'note', r'doc\file1.txt', '', '', '', r'form\filea.txt', 'a_b'],
+                           ['30602', '', 'note', '', '', '', '', r'form\a.txt', ''],
+                           ['30603', '', '', '', '', '', 'started Tue', '', 'a_b']],
+                          columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
+                                   'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_check = appraisal_check_df(df, 'case', 'Casework')
 
         # Tests the values in df_check are correct.
         result = df_to_list(df_check)
-        expected = [['zip', 'in_text', 'in_document_name', 'in_fillin', 'out_text', 'out_document_name', 'out_fillin',
-                     'Appraisal_Category']]
+        expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
+                     'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for no column")
 
 

--- a/tests/css_archiving_format/test_check_metadata_formatting.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting.py
@@ -29,10 +29,10 @@ class MyTestCase(unittest.TestCase):
         df = pd.DataFrame([['30601', np.nan], ['30602', '20001212.0600'], ['30603', '20001212'], ['30604', '2000'],
                            ['30605', '2000-12-12'], ['30606', 'Dec 12, 2000'], ['30606', 'rcvd 20001212']],
                           columns=['zip', 'in_date'])
-        state_mismatch = check_metadata_formatting('in_date', df, 'test_data')
+        in_date_mismatch = check_metadata_formatting('in_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 5, "Problem with test for in_date, count")
+        self.assertEqual(in_date_mismatch, 5, "Problem with test for in_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_in_date.csv'))
@@ -46,10 +46,10 @@ class MyTestCase(unittest.TestCase):
         df = pd.DataFrame([['30601', np.nan], ['30602', '20001212.0600'], ['30603', '20001212'], ['30604', '2000'],
                            ['30605', '2000-12-12'], ['30606', 'Dec 12, 2000'], ['30606', 'rcvd 20001212']],
                           columns=['zip', 'out_date'])
-        state_mismatch = check_metadata_formatting('out_date', df, 'test_data')
+        out_date_mismatch = check_metadata_formatting('out_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 5, "Problem with test for out_date, count")
+        self.assertEqual(out_date_mismatch, 5, "Problem with test for out_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_out_date.csv'))
@@ -79,25 +79,55 @@ class MyTestCase(unittest.TestCase):
         df = pd.DataFrame([['GA', '30601'], ['MS', '306024444'], ['GA', '30603-0001'], ['TX', 'no zip'],
                            ['GA', np.nan], ['DC', 'no zip'], ['GA', np.nan], ['MO', '3060'], ['GA', '30603-XXXX']],
                           columns=['state', 'zip'])
-        state_mismatch = check_metadata_formatting('zip', df, 'test_data')
+        zip_mismatch = check_metadata_formatting('zip', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 4, "Problem with test for zip, count")
+        self.assertEqual(zip_mismatch, 4, "Problem with test for zip, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_zip.csv'))
         expected = [['state', 'zip'], ['MS', '306024444'], ['TX', 'no zip'], ['DC', 'no zip'], ['MO', '3060']]
         self.assertEqual(result, expected, "Problem with test for zip, report")
 
+    def test_column_blank(self):
+        """Test for a column that is entirely blank, which would be the same for any column"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([[np.nan, '30601'], [np.nan, '38602'], [np.nan, '30603-0001'], [np.nan, '76621']],
+                          columns=['state', 'zip'])
+        state_mismatch = check_metadata_formatting('state', df, 'test_data')
+
+        # Tests the returned row count is correct.
+        self.assertEqual(state_mismatch, 'column_blank', "Problem with test for column_blank, count")
+
+        # Tests the report was not made.
+        result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_state.csv'))
+        expected = False
+        self.assertEqual(result, expected, "Problem with test for no column_blank, report")
+
+    def test_column_missing(self):
+        """Test for a column that is missing, which would be the same for any column"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['GA', '30601'], ['MS', '38602'], ['GA', '30603-0001'], ['TX', '76621']],
+                          columns=['state', 'zip'])
+        out_date_mismatch = check_metadata_formatting('out_date', df, 'test_data')
+
+        # Tests the returned row count is correct.
+        self.assertEqual(out_date_mismatch, 'column_missing', "Problem with test for column_missing, count")
+
+        # Tests the report was not made.
+        result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_date.csv'))
+        expected = False
+        self.assertEqual(result, expected, "Problem with test for column_missing, report")
+
     def test_no_errors(self):
         """Test for the column has no formatting errors, which would be the same for any column"""
         # Makes a dataframe to use as test input and runs the function.
         df = pd.DataFrame([['GA', '30601'], ['MS', '38602'], ['GA', '30603-0001'], ['TX', '76621']],
                           columns=['state', 'zip'])
-        state_mismatch = check_metadata_formatting('zip', df, 'test_data')
+        zip_mismatch = check_metadata_formatting('zip', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 0, "Problem with test for no errors, count")
+        self.assertEqual(zip_mismatch, 0, "Problem with test for no errors, count")
 
         # Tests the report was not made.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip.csv'))

--- a/tests/css_archiving_format/test_check_metadata_formatting_multi.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting_multi.py
@@ -89,6 +89,44 @@ class MyTestCase(unittest.TestCase):
                     [30602, 'root\\e:\\emailobj\\200202\\416120451.txt']]
         self.assertEqual(result, expected, "Problem with test for e, report")
 
+    def test_column_blank(self):
+        """Test for when the column is blank"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['30601', np.nan],
+                           ['30602', np.nan],
+                           ['30603', np.nan],
+                           ['30604', np.nan],
+                           ['30605', np.nan]],
+                          columns=['zip', 'out_document_name'])
+        out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
+
+        # Tests the returned row count is correct.
+        self.assertEqual(out_document_name_mismatch, 'column_blank', "Problem with test for 'column_blank', count")
+
+        # Tests the report was not made
+        result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
+        expected = False
+        self.assertEqual(result, expected, "Problem with test for 'column_blank', report")
+
+    def test_column_missing(self):
+        """Test for when the column is missing"""
+        # Makes a dataframe to use as test input and runs the function.
+        df = pd.DataFrame([['30601', '..\\documents\\BlobExport\\folder1\\file1.txt'],
+                           ['30602', '..\\documents\\BlobExport\\folder2\\file2.txt'],
+                           ['30603', '\\\\smith-atlanta\\dos\\public\\folder1\\folder2\\file1.txt'],
+                           ['30604', '\\\\smith-atlanta\\dos\\public\\folder1\\folder2\\file2.txt'],
+                           ['30605', '..\\documents\\BlobExport\\folder2\\file3.txt']],
+                          columns=['zip', 'in_document_name'])
+        out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
+
+        # Tests the returned row count is correct.
+        self.assertEqual(out_document_name_mismatch, 'column_missing', "Problem with test for column_missing, count")
+
+        # Tests the report was not made
+        result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
+        expected = False
+        self.assertEqual(result, expected, "Problem with test for column_missing, report")
+
     def test_no_errors(self):
         """Test for both patterns when there are no errors or blanks"""
         # Makes a dataframe to use as test input and runs the function.

--- a/tests/css_archiving_format/test_delete_appraisal_letters.py
+++ b/tests/css_archiving_format/test_delete_appraisal_letters.py
@@ -37,106 +37,106 @@ class MyTestCase(unittest.TestCase):
     def test_in_document_name(self):
         """Test for deleting files in the in_document_name column"""
         # Makes a copy of the test data in the repo, since the script alters the data.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'in_document_name')
-        shutil.copytree(os.path.join(output_dir, 'Name_Constituent_Mail_Export_copy'),
-                        os.path.join(output_dir, 'Name_Constituent_Mail_Export'))
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'in_document_name')
+        shutil.copytree(os.path.join(output_directory, 'Name_Constituent_Mail_Export_copy'),
+                        os.path.join(output_directory, 'Name_Constituent_Mail_Export'))
 
         # Makes variables needed as function input and runs the function being tested.
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Anderson', r'..\documents\BlobExport\objects\111111.txt',
                                       r'..\documents\BlobExport\formletters\form_a.txt', 'Academy_Application'],
                                      ['Blue', r'..\documents\BlobExport\objects\222222.txt', '',
                                       'Academy_Application']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\objects\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\111111.txt'.replace('..', input_directory),
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
-                    [r'..\documents\objects\222222.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\222222.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'],]
         self.assertEqual(result, expected, "Problem with test for in_document_name, file deletion log")
 
-        # Tests the contents of the input_dir, that all files that should be deleted are gone.
-        result = files_in_dir(input_dir)
+        # Tests the contents of the input_directory, that all files that should be deleted are gone.
+        result = files_in_dir(input_directory)
         expected = ['form_a.txt', '333333.txt']
         self.assertEqual(result, expected, "Problem with test for in_document_name, directory contents")
 
     def test_in_skip(self):
         """Test for deleting files in the in_document_name column, where some rows should be skipped"""
         # Makes a copy of the test data in the repo, since the script alters the data.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'in_document_name')
-        shutil.copytree(os.path.join(output_dir, 'Name_Constituent_Mail_Export_copy'),
-                        os.path.join(output_dir, 'Name_Constituent_Mail_Export'))
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'in_document_name')
+        shutil.copytree(os.path.join(output_directory, 'Name_Constituent_Mail_Export_copy'),
+                        os.path.join(output_directory, 'Name_Constituent_Mail_Export'))
 
         # Makes variables needed as function input and runs the function being tested.
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Abe', r'..\documents\BlobExport\objects\111111.txt', '', 'Academy_Application'],
                                      ['Blue', r'..\documents\BlobExport\objects\222222.txt', '', 'Academy_Application'],
                                      ['Cooper', '', r'..\documents\BlobExport\formletters\test.txt', 'Casework'],
                                      ['Dane', 'nan', r'..\documents\BlobExport\formletters\test.txt', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\objects\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\111111.txt'.replace('..', input_directory),
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
-                    [r'..\documents\objects\222222.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\222222.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'], ]
         self.assertEqual(result, expected, "Problem with test for in_skip, file deletion log")
 
-        # Tests the contents of the input_dir, that all files that should be deleted are gone.
-        result = files_in_dir(input_dir)
+        # Tests the contents of the input_directory, that all files that should be deleted are gone.
+        result = files_in_dir(input_directory)
         expected = ['form_a.txt', '333333.txt']
         self.assertEqual(result, expected, "Problem with test for in_skip, directory contents")
 
     def test_out_document_name(self):
         """Test for deleting files in the out_document_name column"""
         # Makes a copy of the test data in the repo, since the script alters the data.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'out_document_name')
-        shutil.copytree(os.path.join(output_dir, 'Name_Constituent_Mail_Export_copy'),
-                        os.path.join(output_dir, 'Name_Constituent_Mail_Export'))
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'out_document_name')
+        shutil.copytree(os.path.join(output_directory, 'Name_Constituent_Mail_Export_copy'),
+                        os.path.join(output_directory, 'Name_Constituent_Mail_Export'))
 
         # Makes variables needed as function input and runs the function being tested.
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Dudley', '', r'\\office-dc\dos\public\letter\111111.txt', 'Academy_Application'],
                                      ['Evans', '', r'\\office-atl\dos\public\letter\333333.txt', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\letter\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\letter\111111.txt'.replace('..', input_directory),
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
-                    [r'..\documents\letter\333333.txt'.replace('..', input_dir),
+                    [r'..\documents\letter\333333.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
         self.assertEqual(result, expected, "Problem with test for out_document_name, file deletion log")
 
-        # Tests the contents of the input_dir, that all files that should be deleted are gone.
-        result = files_in_dir(input_dir)
+        # Tests the contents of the input_directory, that all files that should be deleted are gone.
+        result = files_in_dir(input_directory)
         expected = ['form_a.txt', 'test.txt', '222222.txt']
         self.assertEqual(result, expected, "Problem with test for out_document_name, directory contents")
 
     def test_out_skip(self):
         """Test for deleting files in the out_document_name column, where some rows should be skipped"""
         # Makes a copy of the test data in the repo, since the script alters the data.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'out_document_name')
-        shutil.copytree(os.path.join(output_dir, 'Name_Constituent_Mail_Export_copy'),
-                        os.path.join(output_dir, 'Name_Constituent_Mail_Export'))
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'out_document_name')
+        shutil.copytree(os.path.join(output_directory, 'Name_Constituent_Mail_Export_copy'),
+                        os.path.join(output_directory, 'Name_Constituent_Mail_Export'))
 
         # Makes variables needed as function input and runs the function being tested.
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Anderson', '', r'\\office-dc\dos\public\form\form_a.txt', 'Casework'],
                                      ['Blue', '', r'\\office-dc\dos\public\letter', 'Casework'],
                                      ['Coop', '', '', 'Casework'],
@@ -144,21 +144,21 @@ class MyTestCase(unittest.TestCase):
                                      ['Evans', '', r'\\office-atl\dos\public\letter\333333.txt', 'Casework'],
                                      ['Fay', '', 'nan', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\letter\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\letter\111111.txt'.replace('..', input_directory),
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
-                    [r'..\documents\letter\333333.txt'.replace('..', input_dir),
+                    [r'..\documents\letter\333333.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
         self.assertEqual(result, expected, "Problem with test for out_skip, file deletion log")
 
-        # Tests the contents of the input_dir, that all files that should be deleted are gone.
-        result = files_in_dir(input_dir)
+        # Tests the contents of the input_directory, that all files that should be deleted are gone.
+        result = files_in_dir(input_directory)
         expected = ['form_a.txt', 'test.txt', '222222.txt']
         self.assertEqual(result, expected, "Problem with test for out_skip, directory contents")
 
@@ -166,16 +166,16 @@ class MyTestCase(unittest.TestCase):
         """Test for when paths in the metadata do not match expected patterns"""
         # Makes variables needed as function input and runs the function being tested.
         # Makes variables needed as function input and runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'error_new')
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'error_new')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Anderson', r'objects\111111.txt', r'form\test.txt', 'Academy_Application'],
                                      ['Evans', '', r'indivletters\500.txt', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [r'objects\111111.txt', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
@@ -187,44 +187,44 @@ class MyTestCase(unittest.TestCase):
     def test_filenotfounderror_in(self):
         """Test for when files in in_document_name are not present and cannot be deleted"""
         # Makes variables needed as function input and runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'filenotfounderror')
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'filenotfounderror')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Anderson', r'..\documents\BlobExport\objects\111111.txt',
                                       r'..\documents\BlobExport\formletters\test.txt', 'Academy_Application'],
                                      ['Evans', r'..\documents\BlobExport\indivletters\500.txt', '', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\objects\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\111111.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
-                    [r'..\documents\indivletters\500.txt'.replace('..', input_dir),
+                    [r'..\documents\indivletters\500.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
         self.assertEqual(result, expected, "Problem with test for filenotfounderror - in, file deletion log")
 
     def test_filenotfounderror_out(self):
         """Test for when files in out_document_name are not present and cannot be deleted"""
         # Makes variables needed as function input and runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'filenotfounderror')
-        input_dir = os.path.join(output_dir, 'Name_Constituent_Mail_Export')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'filenotfounderror')
+        input_directory = os.path.join(output_directory, 'Name_Constituent_Mail_Export')
         appraisal_df = pd.DataFrame([['Anderson', '', r'..\documents\BlobExport\objects\111111.txt',
                                       'Academy_Application'],
                                      ['Evans', '', r'..\documents\BlobExport\indivletters\500.txt', 'Casework']],
                                     columns=['last', 'in_document_name', 'out_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_dir, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [r'..\documents\objects\111111.txt'.replace('..', input_dir),
+                    [r'..\documents\objects\111111.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
-                    [r'..\documents\indivletters\500.txt'.replace('..', input_dir),
+                    [r'..\documents\indivletters\500.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
         self.assertEqual(result, expected, "Problem with test for filenotfounderror - out, file deletion log")
 

--- a/tests/css_archiving_format/test_file_deletion_log.py
+++ b/tests/css_archiving_format/test_file_deletion_log.py
@@ -37,8 +37,8 @@ class MyTestCase(unittest.TestCase):
         today = date.today().strftime('%Y-%m-%d')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
-                    [file_path_1, 0.0, '2025-02-24', today, '89D31DC38A6C7D68653F452A2F44AC3D', 'Academy_Application'],
-                    [file_path_2, 1.2, '2025-02-24', today, '9452DF84756C849AE0ED9FE2A14948F5', 'Casework']]
+                    [file_path_1, 0.0, '2025-04-07', today, '89D31DC38A6C7D68653F452A2F44AC3D', 'Academy_Application'],
+                    [file_path_2, 1.2, '2025-04-07', today, '9452DF84756C849AE0ED9FE2A14948F5', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for delete two")
 
     def test_error_new(self):

--- a/tests/css_archiving_format/test_find_academy_rows.py
+++ b/tests/css_archiving_format/test_find_academy_rows.py
@@ -54,7 +54,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for all patterns, df_academy_check")
 
     def test_in_text(self):
-        """Test for when column in_text contains "academy nomination" (cass-insensitive)"""
+        """Test for when column in_text contains academy nomination"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Military', 'For Academy Nomination Letter', '', '', 'Military', '', '', ''],
                               ['30601', 'Economy', '', '', '', 'Economy', '', '', ''],
@@ -84,10 +84,10 @@ class MyTestCase(unittest.TestCase):
         """Test for when column in_topic contains one of the topics indicating academy applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Science Academy', '', '', '', 'Water', '', '', ''],
-                              ['30601', 'Military Service Academy', '', '', '', 'Admin', '', '', ''],
+                              ['30601', 'military service academy', '', '', '', 'Admin', '', '', ''],
                               ['30602', 'Military^Academy Applicant', '', '', '', '', '', '', ''],
                               ['30603', 'Arts', '', '', '', '', '', '', ''],
-                              ['30604', 'Military Service Academy^ADMIN', '', '', '', '', '', '', '']],
+                              ['30604', 'MILITARY SERVICE ACADEMY^ADMIN', '', '', '', '', '', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                                       'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
         df_academy, df_academy_check = find_academy_rows(md_df)
@@ -96,9 +96,9 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_academy)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30601', 'Military Service Academy', '', '', '', 'Admin', '', '', '', 'Academy_Application'],
+                    ['30601', 'military service academy', '', '', '', 'Admin', '', '', '', 'Academy_Application'],
                     ['30602', 'Military^Academy Applicant', '', '', '', '', '', '', '', 'Academy_Application'],
-                    ['30604', 'Military Service Academy^ADMIN', '', '', '', '', '', '', '', 'Academy_Application']]
+                    ['30604', 'MILITARY SERVICE ACADEMY^ADMIN', '', '', '', '', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_academy")
 
         # Tests the values in df_academy_check are correct.
@@ -130,7 +130,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_academy_check")
 
     def test_out_text(self):
-        """Test for when column out_text contains "academy nomination" (cass-insensitive)"""
+        """Test for when column out_text contains academy nomination"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', '', '', '', '', '', 'for academy nomination', '', ''],
                               ['30601', '', 'note', '', '', '', 'Academy Nomination acceptance', '', ''],
@@ -163,9 +163,9 @@ class MyTestCase(unittest.TestCase):
         """Test for when column out_topic contains one of the topics indicating academy applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Transportation', '', '', '', 'Academy', '', '', ''],
-                              ['30601', 'General', '', '', '', 'General^Military Service Academy', '', '', ''],
+                              ['30601', 'General', '', '', '', 'General^military service academy', '', '', ''],
                               ['30602', 'General', '', '', '', 'Science Academy', 'Note', '', ''],
-                              ['30603', '', '', '', '', 'Academy Applicant^Military', '', '', ''],
+                              ['30603', '', '', '', '', 'Academy APPLICANT^Military', '', '', ''],
                               ['30604', '', '', '', '', 'Academy Applicant', '', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                                       'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
@@ -175,9 +175,9 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_academy)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30601', 'General', '', '', '', 'General^Military Service Academy', '', '', '',
+                    ['30601', 'General', '', '', '', 'General^military service academy', '', '', '',
                      'Academy_Application'],
-                    ['30603', '', '', '', '', 'Academy Applicant^Military', '', '', '', 'Academy_Application'],
+                    ['30603', '', '', '', '', 'Academy APPLICANT^Military', '', '', '', 'Academy_Application'],
                     ['30604', '', '', '', '', 'Academy Applicant', '', '', '', 'Academy_Application']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_academy")
 

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -49,12 +49,12 @@ class MyTestCase(unittest.TestCase):
     def test_in_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
-        md_df = pd.DataFrame([['30600', 'Casework', '', '', '', 'Admin', '', '', ''],
+        md_df = pd.DataFrame([['30600', 'CASEWORK', '', '', '', 'Admin', '', '', ''],
                               ['30601', 'Keep', '', '', '', '', 'note', '', ''],
                               ['30602', 'Casework Issues', '', '', '', 'Admin', '', '', ''],
                               ['30603', 'Prison Case', '', '', '', 'Justice', 'note', '', ''],
                               ['30604', 'Healthcare^Casework', '', '', '', 'Health', '', '', ''],
-                              ['30605', 'Casework Issues^Social Security', '', '', '', 'SSA', 'note', '', ''],
+                              ['30605', 'casework issues^Social Security', '', '', '', 'SSA', 'note', '', ''],
                               ['30606', 'Prison Case^No Reply', '', '', '', 'Justice', '', '', ''],
                               ['30607', 'Keep', '', '', '', 'Legal', 'CASE OF THE CENTURY', '', ''],
                               ['30608', 'Casework^Casework Issues', '', '', '', 'Admin', '', '', '']],
@@ -66,11 +66,11 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_casework)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30600', 'Casework', '', '', '', 'Admin', '', '', '', 'Casework'],
+                    ['30600', 'CASEWORK', '', '', '', 'Admin', '', '', '', 'Casework'],
                     ['30602', 'Casework Issues', '', '', '', 'Admin', '', '', '', 'Casework'],
                     ['30603', 'Prison Case', '', '', '', 'Justice', 'note', '', '', 'Casework'],
                     ['30604', 'Healthcare^Casework', '', '', '', 'Health', '', '', '', 'Casework'],
-                    ['30605', 'Casework Issues^Social Security', '', '', '', 'SSA', 'note', '', '', 'Casework'],
+                    ['30605', 'casework issues^Social Security', '', '', '', 'SSA', 'note', '', '', 'Casework'],
                     ['30606', 'Prison Case^No Reply', '', '', '', 'Justice', '', '', '', 'Casework'],
                     ['30608', 'Casework^Casework Issues', '', '', '', 'Admin', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_casework")
@@ -138,10 +138,10 @@ class MyTestCase(unittest.TestCase):
         """Test for when the column in_topic contains a topic that indicates casework"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Admin', '', '', '', 'Casework', '', '', ''],
-                              ['30601', 'Admin', '', '', '', 'Healthcare^Casework', '', '', ''],
+                              ['30601', 'Admin', '', '', '', 'Healthcare^CASEWORK', '', '', ''],
                               ['30602', 'SSA', '', '', '', 'Casework Issues^Social Security', 'note', '', ''],
                               ['30603', '', '', '', '', 'Prison Case', '', '', ''],
-                              ['30604', '', '', '', '', 'Casework^Casework Issues', '', '', ''],
+                              ['30604', '', '', '', '', 'casework^casework Issues', '', '', ''],
                               ['30605', 'Admin', '', '', '', '', '', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                                       'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
@@ -152,10 +152,10 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Admin', '', '', '', 'Casework', '', '', '', 'Casework'],
-                    ['30601', 'Admin', '', '', '', 'Healthcare^Casework', '', '', '', 'Casework'],
+                    ['30601', 'Admin', '', '', '', 'Healthcare^CASEWORK', '', '', '', 'Casework'],
                     ['30602', 'SSA', '', '', '', 'Casework Issues^Social Security', 'note', '', '', 'Casework'],
                     ['30603', '', '', '', '', 'Prison Case', '', '', '', 'Casework'],
-                    ['30604', '', '', '', '', 'Casework^Casework Issues', '', '', '', 'Casework']]
+                    ['30604', '', '', '', '', 'casework^casework Issues', '', '', '', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_casework")
 
         # Tests the values in df_casework_check are correct.

--- a/tests/css_archiving_format/test_find_job_rows.py
+++ b/tests/css_archiving_format/test_find_job_rows.py
@@ -46,8 +46,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for all patterns, df_job_check")
 
     def test_in_document_name(self):
-        """Test for when column in_document_name contains a word or phrase indicating job applications
-        (case-insensitive)"""
+        """Test for when column in_document_name contains a word or phrase indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', '', '', ''],
                               ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', '', '', ''],
@@ -77,7 +76,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
 
     def test_in_text(self):
-        """Test for when column in_text contains a word or phrase indicating job applications (case-insensitive)"""
+        """Test for when column in_text contains a word or phrase indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Gen', ' new job request', '', '', 'Gen', 'info sent', '', ''],
                               ['30601', 'Admin', 'job requested', '', '', 'Admin', '', r'..\doc\response.doc', ''],
@@ -113,10 +112,10 @@ class MyTestCase(unittest.TestCase):
         """Test for when column in_topic contains one of the topics indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Intern^General', '', '', '', '', '', '', ''],
-                              ['30601', 'Admin^Resumes', '', '', '', '', 'Note', '', ''],
+                              ['30601', 'Admin^RESUMES', '', '', '', '', 'Note', '', ''],
                               ['30602', 'Housing', '', '', '', 'Housing', '', '', ''],
                               ['30603', 'Resumes', '', '', '', 'Economy', '', '', ''],
-                              ['30604', 'Intern', '', '', '', '', '', '', ''],
+                              ['30604', 'intern', '', '', '', '', '', '', ''],
                               ['30605', 'Job Hunting', '', '', '', '', '', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                                       'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
@@ -127,9 +126,9 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Intern^General', '', '', '', '', '', '', '', 'Job_Application'],
-                    ['30601', 'Admin^Resumes', '', '', '', '', 'Note', '', '', 'Job_Application'],
+                    ['30601', 'Admin^RESUMES', '', '', '', '', 'Note', '', '', 'Job_Application'],
                     ['30603', 'Resumes', '', '', '', 'Economy', '', '', '', 'Job_Application'],
-                    ['30604', 'Intern', '', '', '', '', '', '', '', 'Job_Application']]
+                    ['30604', 'intern', '', '', '', '', '', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_job")
 
         # Tests the values in df_job_check are correct.
@@ -162,8 +161,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_job_check")
 
     def test_out_document_name(self):
-        """Test for when column out_document_name contains a word or phrase indicating job applications 
-        (case-insensitive)"""
+        """Test for when column out_document_name contains a word or phrase indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Admin', '', '', '', '', '', r'..\doc\Doe Job Interview.txt', ''],
                               ['30601', 'Arts', '', '', '', '', '', r'..\doc\job_file.txt', ''],
@@ -193,7 +191,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
 
     def test_out_text(self):
-        """Test for when column out_text contains a word or phrase indicating job applications (case-insensitive)"""
+        """Test for when column out_text contains a word or phrase indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Farms', '', '', '', 'Agriculture', 'Job numbers', '', ''],
                               ['30601', 'Admin', '', '', '', 'Admin', 'District Job Request', '', ''],
@@ -229,9 +227,9 @@ class MyTestCase(unittest.TestCase):
         """"Test for when column out_topic contains one of the topics indicating job applications"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', '', '', '', '', 'Economy', 'text', r'..\doc\form\econ.doc', ''],
-                              ['30601', '', '', '', '', 'Gen^Resumes', '', '', ''],
+                              ['30601', '', '', '', '', 'Gen^resumes', '', '', ''],
                               ['30602', '', '', '', '', 'Intern', '', '', ''],
-                              ['30603', '', '', '', '', 'Intern^Admin', 'note', '', ''],
+                              ['30603', '', '', '', '', 'INTERN^Admin', 'note', '', ''],
                               ['30604', '', '', '', '', 'Water', '', '', ''],
                               ['30605', '', '', '', '', 'Resumes', 'note', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
@@ -242,9 +240,9 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_job)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30601', '', '', '', '', 'Gen^Resumes', '', '', '', 'Job_Application'],
+                    ['30601', '', '', '', '', 'Gen^resumes', '', '', '', 'Job_Application'],
                     ['30602', '', '', '', '', 'Intern', '', '', '', 'Job_Application'],
-                    ['30603', '', '', '', '', 'Intern^Admin', 'note', '', '', 'Job_Application'],
+                    ['30603', '', '', '', '', 'INTERN^Admin', 'note', '', '', 'Job_Application'],
                     ['30605', '', '', '', '', 'Resumes', 'note', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_job")
 

--- a/tests/css_archiving_format/test_find_job_rows.py
+++ b/tests/css_archiving_format/test_find_job_rows.py
@@ -29,14 +29,14 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_job)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30602', 'Intern', '', '', '', 'Resume', '', '', '', 'Job_Application'],
-                    ['30601', '', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc',
-                     '', 'Job_Application'],
                     ['30600', 'Resume', 'job request', r'..\doc\resume.txt', '', 'Resume', 'job request', '',
                      '', 'Job_Application'],
+                    ['30602', 'Intern', '', '', '', 'Resume', '', '', '', 'Job_Application'],
                     ['30603', 'Resume', 'job request', '', '', '', '', '', '', 'Job_Application'],
-                    ['30604', '', 'Job Request', '', '', '', 'job request', '', '', 'Job_Application'],
-                    ['30605', 'Admin', 'job request', '', '', 'Resume', '', r'..\doc\resume.txt', '', 'Job_Application']]
+                    ['30601', '', '', '', '', 'Intern', 'summer job request', r'..\doc\job interview.doc',
+                     '', 'Job_Application'],
+                    ['30605', 'Admin', 'job request', '', '', 'Resume', '', r'..\doc\resume.txt', '', 'Job_Application'],
+                    ['30604', '', 'Job Request', '', '', '', 'job request', '', '', 'Job_Application']]
         self.assertEqual(result, expected, "Problem with test for all patterns, df_job")
 
         # Tests the values in df_job_check are correct.

--- a/tests/css_archiving_format/test_find_recommendation_rows.py
+++ b/tests/css_archiving_format/test_find_recommendation_rows.py
@@ -54,7 +54,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for all patterns, df_recommendations_check")
 
     def test_in_text(self):
-        """Test for when column in_text contains a phrase indicating recommendations (case-insensitive)"""
+        """Test for when column in_text contains a phrase indicating recommendations"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Admin', 'Senator wrote recommendation', '', '', '', '', '', ''],
                               ['30601', 'Admin', 'policy for recommendations sent', '', '', 'Admin', '', '', ''],
@@ -87,8 +87,8 @@ class MyTestCase(unittest.TestCase):
         """Test for when column in_topic contains Recommendations"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Recommendations', 'note', '', '', '', '', '', ''],
-                              ['30601', 'Admin^Recommendations', '', '', '', '', '', '', ''],
-                              ['30602', 'Recommendations^Admin', '', '', '', '', '', '', ''],
+                              ['30601', 'Admin^recommendations', '', '', '', '', '', '', ''],
+                              ['30602', 'RECOMMENDATIONS^Admin', '', '', '', '', '', '', ''],
                               ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', ''],
                               ['30604', '', '', '', '', 'Gen', '', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
@@ -100,8 +100,8 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Recommendations', 'note', '', '', '', '', '', '', 'Recommendation'],
-                    ['30601', 'Admin^Recommendations', '', '', '', '', '', '', '', 'Recommendation'],
-                    ['30602', 'Recommendations^Admin', '', '', '', '', '', '', '', 'Recommendation']]
+                    ['30601', 'Admin^recommendations', '', '', '', '', '', '', '', 'Recommendation'],
+                    ['30602', 'RECOMMENDATIONS^Admin', '', '', '', '', '', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
@@ -133,7 +133,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_recommendations_check")
 
     def test_out_text(self):
-        """Test for when column out_text contains a phrase indicating recommendations (case-insensitive)"""
+        """Test for when column out_text contains a phrase indicating recommendations"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', 'Admin', 'note', '', '', '', 'Doe letter of recommendation', '', ''],
                               ['30601', 'Admin', 'note', '', '', '', 'Policy for recommendations sent', '', ''],
@@ -167,9 +167,9 @@ class MyTestCase(unittest.TestCase):
         """Test for when column out_topic contains Recommendations"""
         # Makes a dataframe to use as test input and runs the function.
         md_df = pd.DataFrame([['30600', '', '', '', '', 'Water', 'Policy Recommendation', '', ''],
-                              ['30601', 'General', '', '', '', 'General^Recommendations', '', '', ''],
+                              ['30601', 'General', '', '', '', 'General^recommendations', '', '', ''],
                               ['30602', 'Water', '', '', '', '', 'Recommendation', '', ''],
-                              ['30603', '', 'note', '', '', 'Recommendations', '', '', ''],
+                              ['30603', '', 'note', '', '', 'RECOMMENDATIONS', '', '', ''],
                               ['30604', 'Admin', '', '', '', 'Recommendations^Admin', 'note', '', '']],
                              columns=['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                                       'out_topic', 'out_text', 'out_document_name', 'out_fillin'])
@@ -179,8 +179,8 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_recommendations)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30601', 'General', '', '', '', 'General^Recommendations', '', '', '', 'Recommendation'],
-                    ['30603', '', 'note', '', '', 'Recommendations', '', '', '', 'Recommendation'],
+                    ['30601', 'General', '', '', '', 'General^recommendations', '', '', '', 'Recommendation'],
+                    ['30603', '', 'note', '', '', 'RECOMMENDATIONS', '', '', '', 'Recommendation'],
                     ['30604', 'Admin', '', '', '', 'Recommendations^Admin', 'note', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for out_topic, df_recommendations")
 

--- a/tests/css_archiving_format/test_find_recommendation_rows.py
+++ b/tests/css_archiving_format/test_find_recommendation_rows.py
@@ -101,14 +101,14 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Recommendations', 'note', '', '', '', '', '', '', 'Recommendation'],
                     ['30601', 'Admin^recommendations', '', '', '', '', '', '', '', 'Recommendation'],
-                    ['30602', 'RECOMMENDATIONS^Admin', '', '', '', '', '', '', '', 'Recommendation']]
+                    ['30602', 'RECOMMENDATIONS^Admin', '', '', '', '', '', '', '', 'Recommendation'],
+                    ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', '', 'Recommendation']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
-                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
-                    ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', '', 'Recommendation']]
+                     'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
         self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations_check")
 
     def test_none(self):

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -34,8 +34,7 @@ class MyTestCase(unittest.TestCase):
     def tearDown(self):
         """Remove script outputs, if they were made"""
         # Files saved in the parent of input_directory.
-        filenames = ['archiving_correspondence_redacted.csv', '2021-2022.csv', '2023-2024.csv',
-                     'appraisal_check_log.csv', 'appraisal_delete_log.csv',
+        filenames = ['archiving_correspondence_redacted.csv', 'appraisal_check_log.csv', 'appraisal_delete_log.csv',
                      f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv",
                      'metadata_formatting_errors_state.csv', 'metadata_formatting_errors_zip.csv',
                      'metadata_formatting_errors_in_date.csv', 'metadata_formatting_errors_in_doc.csv',
@@ -46,6 +45,11 @@ class MyTestCase(unittest.TestCase):
             file_path = os.path.join('test_data', 'script', filename)
             if os.path.exists(file_path):
                 os.remove(file_path)
+
+        # Folder of metadata split by congress year
+        cy_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year')
+        if os.path.exists(cy_path):
+            shutil.rmtree(cy_path)
 
         # Copy of input_directory made for some test modes.
         for mode in ('Accession', 'Appraisal', 'Preservation'):
@@ -112,7 +116,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
 
         # Tests the contents of 2021-2022.csv.
-        csv_path = os.path.join('test_data', 'script', '2021-2022.csv')
+        csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '2021-2022.csv')
         result = csv_to_list(csv_path)
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
@@ -123,7 +127,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for access, 2021-2022.csv")
 
         # Tests the contents of 2023-2024.csv.
-        csv_path = os.path.join(os.getcwd(), 'test_data', 'script', '2023-2024.csv')
+        csv_path = os.path.join(os.getcwd(), 'test_data', 'script', 'archiving_correspondence_by_congress_year', '2023-2024.csv')
         result = csv_to_list(csv_path)
         expected = [['city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_document_name', 'out_id', 'out_type', 'out_method',
@@ -137,7 +141,8 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for access, 2023-2024.csv")
 
         # Tests that no undated.csv was made.
-        result = os.path.exists(os.path.join(os.getcwd(), 'test_data', 'script', 'undated.csv'))
+        result = os.path.exists(os.path.join(os.getcwd(), 'test_data', 'script',
+                                             'archiving_correspondence_by_congress_year', 'undated.csv'))
         self.assertEqual(result, False, "Problem with test for access, undated.csv")
 
         # Tests the other script mode outputs were not made.

--- a/tests/css_archiving_format/test_split_congress_year.py
+++ b/tests/css_archiving_format/test_split_congress_year.py
@@ -5,6 +5,7 @@ To simplify input, tests use dataframes with only some of the columns present in
 import numpy as np
 import os
 import pandas as pd
+import shutil
 import unittest
 from css_archiving_format import split_congress_year
 from test_script import csv_to_list
@@ -13,13 +14,9 @@ from test_script import csv_to_list
 class MyTestCase(unittest.TestCase):
 
     def tearDown(self):
-        """Delete the function output, if it was created"""
-        filenames = ['1981-1982.csv', '1987-1988.csv', '1989-1990.csv', '1997-1998.csv',
-                     '2001-2002.csv', '2009-2010.csv', 'undated.csv']
-        for filename in filenames:
-            file_path = os.path.join('test_data', filename)
-            if os.path.exists(file_path):
-                os.remove(file_path)
+        """Delete the function output"""
+        output_path = os.path.join('test_data', 'archiving_correspondence_by_congress_year')
+        shutil.rmtree(output_path)
 
     def test_all(self):
         """Test for a combination of all date values: even, odd, blank, and text"""
@@ -35,14 +32,14 @@ class MyTestCase(unittest.TestCase):
         split_congress_year(md_df, 'test_data')
 
         # Tests that 1981-1982.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '1981-1982.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1981-1982.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 19810505, 'oranges', 19810509, 'fruit'],
                     [30603, 19820505, 'oranges', 19820509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for all years, 1981-1982")
 
         # Tests that 1987-1988.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '1987-1988.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1987-1988.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 19870104, 'cats', 'BLANK', 'pets'],
                     [30601, 19881001, 'dogs', 19881005, 'BLANK'],
@@ -50,7 +47,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for all years, 1987-1988")
 
         # Tests that undated.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', 'undated.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30602, 'BLANK', 'cats', 19890105, 'pets'],
                     [30603, 'date_error', 'oranges', 19820509, 'fruit']]
@@ -65,7 +62,7 @@ class MyTestCase(unittest.TestCase):
         split_congress_year(md_df, 'test_data')
 
         # Tests that undated has the correct values.
-        result = csv_to_list(os.path.join('test_data', 'undated.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 'BLANK', 'dogs', 'BLANK', 'pets'],
                     [30602, 'BLANK', 'cats', 'BLANK', 'pets']]
@@ -80,7 +77,7 @@ class MyTestCase(unittest.TestCase):
         split_congress_year(md_df, 'test_data')
 
         # Tests that undated has the correct values.
-        result = csv_to_list(os.path.join('test_data', 'undated.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 'error', 'cats', 19950105, 'pets'],
                     [30601, 'error_date', 'dogs', 19950105, 'pets']]
@@ -97,7 +94,7 @@ class MyTestCase(unittest.TestCase):
         split_congress_year(md_df, 'test_data')
 
         # Tests that 1989-1990.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '1989-1990.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1989-1990.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 19900104, 'cats', 19900105, 'pets'],
                     [30601, 19901001, 'dogs', 19901005, 'pets'],
@@ -105,7 +102,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for even years, 1989-1990")
 
         # Tests that 2001-2002.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '2001-2002.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2001-2002.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 20020505, 'oranges', 20020509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for even years, 2001-2002")
@@ -121,7 +118,7 @@ class MyTestCase(unittest.TestCase):
         split_congress_year(md_df, 'test_data')
 
         # Tests that 1997-1998.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '1997-1998.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1997-1998.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 19970104, 'cats', 19970105, 'pets'],
                     [30601, 19971001, 'dogs', 19971005, 'pets'],
@@ -129,7 +126,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(result, expected, "Problem with test for odd years, 1997-1998")
 
         # Tests that 2009-2010.csv has the correct values.
-        result = csv_to_list(os.path.join('test_data', '2009-2010.csv'))
+        result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2009-2010.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 20090505, 'oranges', 20090509, 'fruit']]
         self.assertEqual(result, expected, "Problem with test for even years, 2009-2010")

--- a/tests/css_data_interchange_format/test_delete_appraisal_letters.py
+++ b/tests/css_data_interchange_format/test_delete_appraisal_letters.py
@@ -36,20 +36,20 @@ class MyTestCase(unittest.TestCase):
     def test_deletion(self):
         """Test for when the file paths in the metadata match files in the export and the files are deleted"""
         # Makes a copy of the test data in the repo, since the script alters the data.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'deletion')
-        shutil.copytree(os.path.join(output_dir, 'export_copy'),
-                        os.path.join(output_dir, 'export'))
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'deletion')
+        shutil.copytree(os.path.join(output_directory, 'export_copy'),
+                        os.path.join(output_directory, 'export'))
 
         # Makes variables needed as function input and runs the function being tested.
-        input_directory = os.path.join(output_dir, 'export')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', '..\\documents\\objects\\100001.txt', 'Casework'],
                                      ['20241202', '..\\documents\\objects\\200002.txt', 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [os.path.join(input_directory, 'documents', 'objects', '100001.txt'),
@@ -66,16 +66,16 @@ class MyTestCase(unittest.TestCase):
     def test_file_not_found(self):
         """Test for when the file paths in the metadata do not match files in the export"""
         # Makes variables needed as function input and runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'file_not_found')
-        input_directory = os.path.join(output_dir, 'export')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'file_not_found')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', '..\\documents\\objects\\800000.txt', 'Casework'],
                                      ['20241202', '..\\documents\\objects\\900000.txt', 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [os.path.join(input_directory, 'documents', 'objects', '800000.txt'),
@@ -92,18 +92,18 @@ class MyTestCase(unittest.TestCase):
     def test_new_pattern(self):
         """Test for when the file paths in the metadata match files in the export but are a new pattern"""
         # Runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'new_pattern')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'new_pattern')
         # Makes variables needed as function input and runs the function being tested.
-        input_directory = os.path.join(output_dir, 'export')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', '..\\letters\\100001.txt', 'Casework'],
                                      ['20241202', '..\\letters\\200002.txt', 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         # Code needs to be updated to not save (or delete after saving) if the report is empty (header only).
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     ['..\\letters\\100001.txt', 'nan', 'nan', 'nan', 'nan',
@@ -120,17 +120,17 @@ class MyTestCase(unittest.TestCase):
     def test_no_deletion_blank(self):
         """Test for when the file paths in the metadata are blank"""
         # Runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_blank')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_blank')
         # Makes variables needed as function input and runs the function being tested.
-        input_directory = os.path.join(output_dir, 'export')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', np.nan, 'Casework'],
                                      ['20241202', np.nan, 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
         self.assertEqual(result, expected, "Problem with test for no deletion - blank, file deletion log")
@@ -143,17 +143,17 @@ class MyTestCase(unittest.TestCase):
     def test_no_deletion_empty_string(self):
         """Test for when the file paths in the metadata are empty strings"""
         # Runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_empty_string')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_empty_string')
         # Makes variables needed as function input and runs the function being tested.
-        input_directory = os.path.join(output_dir, 'export')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', '', 'Casework'],
                                      ['20241202', '', 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
         self.assertEqual(result, expected, "Problem with test for no deletion - empty string, file deletion log")
@@ -166,18 +166,18 @@ class MyTestCase(unittest.TestCase):
     def test_no_deletion_form(self):
         """Test for when the file paths in the metadata match files in the export but are form letters (not deleted)"""
         # Runs the function being tested.
-        output_dir = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_form')
+        output_directory = os.path.join('test_data', 'delete_appraisal_letters', 'no_deletion_form')
         # Makes variables needed as function input and runs the function being tested.
-        input_directory = os.path.join(output_dir, 'export')
+        input_directory = os.path.join(output_directory, 'export')
         appraisal_df = pd.DataFrame([['20241201', '..\\documents\\formletters\\100001.txt', 'Casework'],
                                      ['20241202', '..\\documents\\formletters\\200002.txt', 'Casework']],
                                     columns=['date_in', 'communication_document_name', 'Appraisal_Category'])
-        delete_appraisal_letters(input_directory, appraisal_df)
+        delete_appraisal_letters(input_directory, output_directory, appraisal_df)
 
         # Tests the contents of the file deletion log.
         # Code needs to be updated to not save (or delete after saving) if the report is empty (header only).
         today = date.today().strftime('%Y-%m-%d')
-        log_path = os.path.join(output_dir, f'file_deletion_log_{today}.csv')
+        log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
         self.assertEqual(result, expected, "Problem with test for no deletion - form, file deletion log")

--- a/tests/css_data_interchange_format/test_find_appraisal_rows.py
+++ b/tests/css_data_interchange_format/test_find_appraisal_rows.py
@@ -1,0 +1,165 @@
+"""
+Tests for the function find_appraisal_rows(),
+which finds metadata rows with topics or text that indicate they are different categories for appraisal
+and return as a df and log results.
+To simplify input, tests use dataframes with only some of the columns present in a real export.
+"""
+import os
+import pandas as pd
+import unittest
+from css_data_interchange_format import find_appraisal_rows
+from test_appraisal_check_df import df_to_list
+from test_script import csv_to_list
+
+
+class MyTestCase(unittest.TestCase):
+
+    def tearDown(self):
+        """Delete the log, if made by the test"""
+        log_paths = [os.path.join('test_data', 'appraisal_check_log.csv'),
+                     os.path.join('test_data', 'appraisal_delete_log.csv')]
+        for log_path in log_paths:
+            if os.path.exists(log_path):
+                os.remove(log_path)
+
+    def test_all_multiple(self):
+        """Test for when all appraisal categories are present and reach row matches multiple categories"""
+        # Makes a dataframe to use as test input and runs the function.
+        md_df = pd.DataFrame([['20240101', 'case1', r'..\documents\academy rejection.txt', 'academy rejection.txt'],
+                              ['20240202', 'academy 01', r'..\documents\formletters\good job.doc', 'good job.doc'],
+                              ['20240303', 'case admin', r'..\documents\formletters\good job.doc', 'good job.doc'],
+                              ['20240404', 'academy02', r'..\documents\casework\good job.doc', 'good job.doc']],
+                             columns=['date_in', 'group_name', 'communication_document_name', 'file_name'])
+        appraisal_df = find_appraisal_rows(md_df, 'test_data')
+
+        # Tests the values in appraisal_df are correct.
+        result = df_to_list(appraisal_df)
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'case1', r'..\documents\academy rejection.txt', 'academy rejection.txt',
+                     'Academy_Application|Casework'],
+                    ['20240202', 'academy 01', r'..\documents\formletters\good job.doc', 'good job.doc',
+                     'Academy_Application|Job_Application'],
+                    ['20240303', 'case admin', r'..\documents\formletters\good job.doc', 'good job.doc',
+                     'Casework|Job_Application'],
+                    ['20240404', 'academy02', r'..\documents\casework\good job.doc', 'good job.doc',
+                     'Academy_Application|Casework|Job_Application']]
+        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_df")
+
+        # Tests the values in appraisal_check_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category']]
+        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_check_log.csv")
+
+        # Tests the values in appraisal_delete_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'case1', r'..\documents\academy rejection.txt', 'academy rejection.txt',
+                     'Academy_Application|Casework'],
+                    ['20240202', 'academy 01', r'..\documents\formletters\good job.doc', 'good job.doc',
+                     'Academy_Application|Job_Application'],
+                    ['20240303', 'case admin', r'..\documents\formletters\good job.doc', 'good job.doc',
+                     'Casework|Job_Application'],
+                    ['20240404', 'academy02', r'..\documents\casework\good job.doc', 'good job.doc',
+                     'Academy_Application|Casework|Job_Application']]
+        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_delete_log.csv")
+
+    def test_all_single(self):
+        """Test for when all appraisal categories are present and each row matches a single category"""
+        # Makes a dataframe to use as test input and runs the function.
+        md_df = pd.DataFrame([['20240101', 'Admin', r'..\documents\objects\academy.txt', 'academy.txt'],
+                              ['20240202', 'Case1', '', ''],
+                              ['20240303', 'jobapp', r'..\documents\objects\position.txt', 'position.txt'],
+                              ['20240404', 'Arts', '', 'artist recommendation.txt'],
+                              ['20240505', 'Admin', r'..\documents\objects\intern rec.txt', ''],
+                              ['20240606', 'Admin',  '', 'legal_case.txt']],
+                             columns=['date_in', 'group_name', 'communication_document_name', 'file_name'])
+        appraisal_df = find_appraisal_rows(md_df, 'test_data')
+
+        # Tests the values in appraisal_df are correct.
+        result = df_to_list(appraisal_df)
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'Admin', r'..\documents\objects\academy.txt', 'academy.txt', 'Academy_Application'],
+                    ['20240202', 'Case1', '', '', 'Casework'],
+                    ['20240303', 'jobapp', r'..\documents\objects\position.txt', 'position.txt', 'Job_Application'],
+                    ['20240505', 'Admin', r'..\documents\objects\intern rec.txt', '', 'Recommendation']]
+        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_df")
+
+        # Tests the values in appraisal_check_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240606', 'Admin', 'nan', 'legal_case.txt', 'Casework'],
+                    ['20240404', 'Arts', 'nan', 'artist recommendation.txt', 'Recommendation']]
+        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_check_log.csv")
+
+        # Tests the values in appraisal_delete_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'Admin', r'..\documents\objects\academy.txt', 'academy.txt', 'Academy_Application'],
+                    ['20240202', 'Case1', 'nan', 'nan', 'Casework'],
+                    ['20240303', 'jobapp', r'..\documents\objects\position.txt', 'position.txt', 'Job_Application'],
+                    ['20240505', 'Admin', r'..\documents\objects\intern rec.txt', 'nan', 'Recommendation']]
+        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_delete_log.csv")
+
+    def test_one(self):
+        """Test for when only one appraisal category is present"""
+        # Makes a dataframe to use as test input and runs the function.
+        md_df = pd.DataFrame([['20240101', 'CASE1', '', ''],
+                              ['20240202', 'case 2', '', ''],
+                              ['20240303', 'Arts', '', ''],
+                              ['20240404', 'Case3', r'..\documents\casework\3.txt', '3.txt'],
+                              ['20240505', 'Econ', r'..\documents\objects\case.txt', 'case.txt'],
+                              ['20240506', 'Econ', r'..\documents\casework\3.txt', '3.txt']],
+                             columns=['date_in', 'group_name', 'communication_document_name', 'file_name'])
+        appraisal_df = find_appraisal_rows(md_df, 'test_data')
+
+        # Tests the values in appraisal_df are correct.
+        result = df_to_list(appraisal_df)
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'CASE1', '', '', 'Casework'],
+                    ['20240202', 'case 2', '', '', 'Casework'],
+                    ['20240404', 'Case3', r'..\documents\casework\3.txt', '3.txt', 'Casework'],
+                    ['20240506', 'Econ', r'..\documents\casework\3.txt', '3.txt', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for one, appraisal_df")
+
+        # Tests the values in appraisal_check_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240505', 'Econ', r'..\documents\objects\case.txt', 'case.txt', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for one, appraisal_check_log.csv")
+
+        # Tests the values in appraisal_delete_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category'],
+                    ['20240101', 'CASE1', 'nan', 'nan', 'Casework'],
+                    ['20240202', 'case 2', 'nan', 'nan', 'Casework'],
+                    ['20240404', 'Case3', r'..\documents\casework\3.txt', '3.txt', 'Casework'],
+                    ['20240506', 'Econ', r'..\documents\casework\3.txt', '3.txt', 'Casework']]
+        self.assertEqual(result, expected, "Problem with test for one, appraisal_delete_log.csv")
+
+    def test_none(self):
+        """Test for when no rows match any appraisal categories"""
+        # Makes a dataframe to use as test input and runs the function.
+        md_df = pd.DataFrame([['20240101', 'arts', r'..\documents\objects\a1.txt', 'a1.txt'],
+                              ['20240202', 'Science', '', ''],
+                              ['20240303', 'Pets', '', '']],
+                             columns=['date_in', 'group_name', 'communication_document_name', 'file_name'])
+        appraisal_df = find_appraisal_rows(md_df, 'test_data')
+
+        # Tests the values in appraisal_df are correct.
+        result = df_to_list(appraisal_df)
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category']]
+        self.assertEqual(result, expected, "Problem with test for something, appraisal_df")
+
+        # Tests the values in appraisal_check_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category']]
+        self.assertEqual(result, expected, "Problem with test for something, appraisal_check_log.csv")
+
+        # Tests the values in appraisal_delete_log.csv are correct.
+        result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
+        expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category']]
+        self.assertEqual(result, expected, "Problem with test for something, appraisal_delete_log.csv")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/css_data_interchange_format/test_script.py
+++ b/tests/css_data_interchange_format/test_script.py
@@ -67,8 +67,9 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the print statement.
         result = output.stdout
-        expected = ('\nThe script is running in access mode.\nIt will remove rows for deleted letters and columns with '
-                    'PII from the merged metadata tables, and make copies of the metadata split by congress year\n')
+        expected = ('\nThe script is running in access mode.\nIt will remove rows for deleted letters, '
+                    'save the merged metadata tables without columns with PII,'
+                    ' and make copies of the metadata split by congress year\n')
         self.assertEqual(result, expected, "Problem with test for access, printed statement")
 
         # Tests the contents of the appraisal_check_log.csv.


### PR DESCRIPTION
Align changes from css_data_interchange_format.py to css_archiving_format.py
- Use appraisal_check_df()
- Expand match for appraisal keywords: singular and case insensitive
- Save congress year csvs to their own folder
- Add error handling to check_metadata_formatting() for empty and missing columns
- Sync some variable names, function descriptions, and comments
- Sync some minor code streamlines