### PR TITLE
CMS DIF Preservation Mode

### DIFF
--- a/cms_data_interchange_format.py
+++ b/cms_data_interchange_format.py
@@ -37,13 +37,11 @@ def check_arguments(arg_list):
     errors = []
 
     # Both arguments are missing (only the script path is present).
-    # Return immediately, or it would also have the error one missing required argument.
     if len(arg_list) == 1:
         errors.append("Missing required arguments, input_directory and script_mode")
-        return input_dir, md_paths, mode, errors
 
     # At least the first argument is present.
-    # Verifies it is a valid path, and if so gets the paths to the expected metadata files.
+    # Verifies it is a valid path, and if so that it contains the expected metadata files.
     if len(arg_list) > 1:
         if os.path.exists(arg_list[1]):
             input_dir = arg_list[1]
@@ -53,9 +51,13 @@ def check_arguments(arg_list):
                     # Key is extracted from the filename, for example 2A.out has a key of 2A.
                     md_paths[file[:2]] = os.path.join(input_dir, file)
                 else:
-                    errors.append(f'Metadata file {file} is not in the input_directory')
+                    errors.append(f'No {file} file in the input_directory')
         else:
             errors.append(f"Provided input_directory '{arg_list[1]}' does not exist")
+
+    # Only one required argument is present.
+    if len(arg_list) == 2:
+        errors.append("Missing one of the required arguments, input_directory or script_mode")
 
     # Both required arguments are present.
     # Verifies the second is one of the expected modes.
@@ -64,8 +66,6 @@ def check_arguments(arg_list):
             mode = arg_list[2]
         else:
             errors.append(f"Provided mode '{arg_list[2]}' is not one of the expected modes")
-    else:
-        errors.append("Missing one of the required arguments, input_directory or script_mode")
 
     # More than the expected two required arguments are present.
     if len(arg_list) > 3:

--- a/cms_data_interchange_format.py
+++ b/cms_data_interchange_format.py
@@ -296,8 +296,15 @@ if __name__ == '__main__':
     # Columns with PII must be removed now to save memory, given the size of the data.
     md_df = read_metadata(metadata_paths_dict)
 
+    # The rest of the script is dependent on the mode.
+
+    # TODO For preservation, prepares the export for the general_aip.py script.
+    if script_mode == 'preservation':
+        print("\nThe script is running in preservation mode.")
+        print("The steps are TBD.")
+
     # For access, makes a copy of the metadata with tables merged and PII removed and
     # makes a copy of the data split by congress year.
-    if script_mode == 'access':
+    elif script_mode == 'access':
         md_df.to_csv(os.path.join(output_directory, 'Access_Copy.csv'), index=False)
         split_congress_year(md_df, output_directory)

--- a/cms_data_interchange_format.py
+++ b/cms_data_interchange_format.py
@@ -60,10 +60,10 @@ def check_arguments(arg_list):
     # Both required arguments are present.
     # Verifies the second is one of the expected modes.
     if len(arg_list) > 2:
-        if arg_list[2] in ('access', 'preservation'):
+        if arg_list[2] in ('accession', 'appraisal', 'preservation', 'access'):
             mode = arg_list[2]
         else:
-            errors.append(f"Provided mode '{arg_list[2]}' is not 'access' or 'preservation'")
+            errors.append(f"Provided mode '{arg_list[2]}' is not one of the expected modes")
     else:
         errors.append("Missing one of the required arguments, input_directory or script_mode")
 

--- a/tests/cms_data_interchange_format/test_check_arguments.py
+++ b/tests/cms_data_interchange_format/test_check_arguments.py
@@ -29,6 +29,46 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(script_mode, 'access', "Problem with correct - access, script_mode")
         self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
 
+    def test_correct_accession(self):
+        """Test for when both required arguments are present, input_directory path exists and
+        all metadata files are present, and mode is accession."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['cms_data_interchange_format.py', input_dir, 'accession']
+        input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_dict = {'1B': os.path.join(input_dir, '1B.out'),
+                         '2A': os.path.join(input_dir, '2A.out'),
+                         '2B': os.path.join(input_dir, '2B.out'),
+                         '2C': os.path.join(input_dir, '2C.out'),
+                         '2D': os.path.join(input_dir, '2D.out'),
+                         '8A': os.path.join(input_dir, '8A.out')}
+        self.assertEqual(input_directory, input_dir, "Problem with correct - accession, input_directory")
+        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - accession, metadata_paths_dict")
+        self.assertEqual(script_mode, 'accession', "Problem with correct - accession, script_mode")
+        self.assertEqual(errors_list, [], "Problem with correct - accession, errors_list")
+
+    def test_correct_appraisal(self):
+        """Test for when both required arguments are present, input_directory path exists and
+        all metadata files are present, and mode is appraisal."""
+        # Runs the function being tested.
+        input_dir = os.path.join('test_data', 'check_arguments', 'correct')
+        sys_argv = ['cms_data_interchange_format.py', input_dir, 'appraisal']
+        input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
+
+        # Tests the value of each of the four variables returned by the function
+        expected_dict = {'1B': os.path.join(input_dir, '1B.out'),
+                         '2A': os.path.join(input_dir, '2A.out'),
+                         '2B': os.path.join(input_dir, '2B.out'),
+                         '2C': os.path.join(input_dir, '2C.out'),
+                         '2D': os.path.join(input_dir, '2D.out'),
+                         '8A': os.path.join(input_dir, '8A.out')}
+        self.assertEqual(input_directory, input_dir, "Problem with correct - appraisal, input_directory")
+        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - appraisal, metadata_paths_dict")
+        self.assertEqual(script_mode, 'appraisal', "Problem with correct - appraisal, script_mode")
+        self.assertEqual(errors_list, [], "Problem with correct - appraisal, errors_list")
+
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists and 
         all metadata files are present, and mode is access."""
@@ -80,7 +120,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(input_directory, input_dir, "Problem with error - script mode, input_directory")
         self.assertEqual(metadata_paths_dict, expected_dict, "Problem with error - script mode, metadata_paths_dict")
         self.assertEqual(script_mode, None, "Problem with error - script mode, script_mode")
-        self.assertEqual(errors_list, ["Provided mode 'mode_error' is not 'access' or 'preservation'"],
+        self.assertEqual(errors_list, ["Provided mode 'mode_error' is not one of the expected modes"],
                          "Problem with error - script mode, errors_list")
 
     def test_missing_both_arg(self):
@@ -107,12 +147,12 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(input_directory, input_dir, "Problem with missing metadata, input_directory")
         self.assertEqual(metadata_paths_dict, {}, "Problem with missing metadata, metadata_paths_dict")
         self.assertEqual(script_mode, 'access', "Problem with missing metadata, script_mode")
-        self.assertEqual(errors_list, ['Metadata file 1B.out is not in the input_directory',
-                                       'Metadata file 2A.out is not in the input_directory',
-                                       'Metadata file 2B.out is not in the input_directory',
-                                       'Metadata file 2C.out is not in the input_directory',
-                                       'Metadata file 2D.out is not in the input_directory',
-                                       'Metadata file 8A.out is not in the input_directory'],
+        self.assertEqual(errors_list, ['No 1B.out file in the input_directory',
+                                       'No 2A.out file in the input_directory',
+                                       'No 2B.out file in the input_directory',
+                                       'No 2C.out file in the input_directory',
+                                       'No 2D.out file in the input_directory',
+                                       'No 8A.out file in the input_directory'],
                          "Problem with missing metadata, errors_list")
 
     def test_missing_metadata_some(self):
@@ -129,9 +169,9 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(input_directory, input_dir, "Problem with missing metadata - some, input_directory")
         self.assertEqual(metadata_paths_dict, expected_dict, "Problem with missing metadata - some, metadata_paths_dict")
         self.assertEqual(script_mode, 'access', "Problem with missing metadata - some, script_mode")
-        self.assertEqual(errors_list, ['Metadata file 1B.out is not in the input_directory',
-                                       'Metadata file 2B.out is not in the input_directory',
-                                       'Metadata file 8A.out is not in the input_directory'],
+        self.assertEqual(errors_list, ['No 1B.out file in the input_directory',
+                                       'No 2B.out file in the input_directory',
+                                       'No 8A.out file in the input_directory'],
                          "Problem with missing metadata - some, errors_list")
 
     def test_missing_one_arg(self):
@@ -166,7 +206,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(metadata_paths_dict, {}, "Problem with too many arguments, metadata_paths_dict")
         self.assertEqual(script_mode, None, "Problem with too many arguments, script_mode")
         self.assertEqual(errors_list, [f"Provided input_directory '{input_dir}' does not exist",
-                                       "Provided mode 'mode_error' is not 'access' or 'preservation'",
+                                       "Provided mode 'mode_error' is not one of the expected modes",
                                        "Provided more than the required arguments, input_directory and script_mode"],
                          "Problem with too many arguments, errors_list")
 

--- a/tests/cms_data_interchange_format/test_data/script/preservation/1B.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/1B.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_data/script/preservation/2A.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/2A.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_data/script/preservation/2B.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/2B.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_data/script/preservation/2C.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/2C.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_data/script/preservation/2D.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/2D.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_data/script/preservation/8A.out
+++ b/tests/cms_data_interchange_format/test_data/script/preservation/8A.out
@@ -1,0 +1,1 @@
+Placeholder for metadata file

--- a/tests/cms_data_interchange_format/test_script.py
+++ b/tests/cms_data_interchange_format/test_script.py
@@ -110,24 +110,38 @@ class MyTestCase(unittest.TestCase):
         expected = "Missing required arguments, input_directory and script_mode\r\n"
         self.assertEqual(result, expected, "Problem with test for error argument, printed error")
 
+    # def test_accession(self):
+    #     """Test for when the script runs correctly in accession mode."""
+    #     # Runs the script.
+    #     script_path = os.path.join(os.getcwd(), '..', '..', 'cms_data_interchange_format.py')
+    #     input_directory = os.path.join('test_data', 'script')
+    #     subprocess.run(f"python {script_path} {input_directory} preservation", shell=True)
+    #
+    #     # Tests the contents of case_remains_log.csv.
+    #     csv_path = os.path.join('test_data', 'case_remains_log.csv')
+    #     result = csv_to_list(csv_path)
+    #     expected = [['city', 'state', 'zip_code', 'country', 'correspondence_type', 'staff', 'date_in', 'date_out',
+    #                  'tickler_date', 'update_date', 'response_type', 'correspondence_code', 'position',
+    #                  '2C_sequence_number', 'document_type', 'correspondence_document_name', 'file_location'],
+    #                 ['City One', 'GA', '30001', 'USA', 'LETTER', 'Staffer_1', '20210110', '20210110', 'BLANK',
+    #                  '20210110', 'LETTER', 'LEGAL CASE', 'CON', '1', 'main', 'legal_con.docx', 'BLANK'],
+    #                 ['Caseyville', 'GA', '30002', 'USA', 'EMAIL', 'Staffer_2', '20220220', '20220220', 'BLANK',
+    #                  '20220220', 'EMAIL', 'MINWAGE', 'PRO', '1', 'main', 'min_wage_pro.docx', 'BLANK']]
+    #     self.assertEqual(result, expected, "Problem with test for preservation, case_remains_log.csv")
+
     def test_preservation(self):
         """Test for when the script runs correctly in preservation mode."""
         # Runs the script.
+        # Since just testing printing right now, using a folder for input_directory that is not an export.
         script_path = os.path.join(os.getcwd(), '..', '..', 'cms_data_interchange_format.py')
-        input_directory = os.path.join('test_data', 'script')
-        subprocess.run(f"python {script_path} {input_directory} preservation", shell=True)
+        input_directory = os.path.join('test_data', 'script', 'preservation')
+        output = subprocess.run(f"python {script_path} {input_directory} preservation",
+                                shell=True, capture_output=True, text=True)
 
-        # Tests the contents of case_remains_log.csv.
-        csv_path = os.path.join('test_data', 'case_remains_log.csv')
-        result = csv_to_list(csv_path)
-        expected = [['city', 'state', 'zip_code', 'country', 'correspondence_type', 'staff', 'date_in', 'date_out',
-                     'tickler_date', 'update_date', 'response_type', 'correspondence_code', 'position',
-                     '2C_sequence_number', 'document_type', 'correspondence_document_name', 'file_location'],
-                    ['City One', 'GA', '30001', 'USA', 'LETTER', 'Staffer_1', '20210110', '20210110', 'BLANK',
-                     '20210110', 'LETTER', 'LEGAL CASE', 'CON', '1', 'main', 'legal_con.docx', 'BLANK'],
-                    ['Caseyville', 'GA', '30002', 'USA', 'EMAIL', 'Staffer_2', '20220220', '20220220', 'BLANK',
-                     '20220220', 'EMAIL', 'MINWAGE', 'PRO', '1', 'main', 'min_wage_pro.docx', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for preservation, case_remains_log.csv")
+        # Tests the print statement.
+        result = output.stdout
+        expected = '\nThe script is running in preservation mode.\nThe steps are TBD.\n'
+        self.assertEqual(result, expected, "Problem with test for preservation, printed statement")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add preservation mode to cms_data_interchange_format.py, which currently just prints the mode. Updated check_arguments to work with all planned modes, including ones not yet implemented.