### PR TITLE
Tests switch expected result

### DIFF
--- a/tests/archival_office/test_check_arguments.py
+++ b/tests/archival_office/test_check_arguments.py
@@ -17,11 +17,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - access, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archive.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - access, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archive.dat'), metadata_path,
                          "Problem with correct - access, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with correct - access, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
+        self.assertEqual('access', script_mode, "Problem with correct - access, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - access, errors_list")
 
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is preservation."""
@@ -31,11 +31,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - preservation, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archive.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - preservation, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archive.dat'), metadata_path,
                          "Problem with correct - preservation, metadata_path")
-        self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
+        self.assertEqual('preservation', script_mode, "Problem with correct - preservation, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - preservation, errors_list")
 
     def test_error_input_directory(self):
         """Test for when the input_directory path does not exist"""
@@ -44,10 +44,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with error input directory, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with error input directory, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error input directory, script_mode")
-        self.assertEqual(errors_list, ["Provided input_directory 'path_error' does not exist"],
+        self.assertEqual(None, input_directory, "Problem with error input directory, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with error input directory, metadata_path")
+        self.assertEqual('access', script_mode, "Problem with error input directory, script_mode")
+        self.assertEqual(["Provided input_directory 'path_error' does not exist"], errors_list,
                          "Problem with error input directory, errors_list")
 
     def test_error_script_mode(self):
@@ -59,11 +59,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with error script mode, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archive.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with error script mode, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archive.dat'), metadata_path,
                          "Problem with error script mode, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with error script mode, script_mode")
-        self.assertEqual(errors_list, ["Provided mode 'mode_error' is not 'access' or 'preservation'"],
+        self.assertEqual(None, script_mode, "Problem with error script mode, script_mode")
+        self.assertEqual(["Provided mode 'mode_error' is not 'access' or 'preservation'"], errors_list,
                          "Problem with error script mode, errors_list")
 
     def test_missing_both(self):
@@ -73,10 +73,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with missing both, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with missing both, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with missing both, script_mode")
-        self.assertEqual(errors_list, ['Missing required arguments, input_directory and script_mode'],
+        self.assertEqual(None, input_directory, "Problem with missing both, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with missing both, metadata_path")
+        self.assertEqual(None, script_mode, "Problem with missing both, script_mode")
+        self.assertEqual(['Missing required arguments, input_directory and script_mode'], errors_list,
                          "Problem with missing both, errors_list")
 
     def test_missing_metadata(self):
@@ -87,10 +87,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with missing metadata, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with missing metadata, metadata_path")
-        self.assertEqual(script_mode, 'preservation', "Problem with missing metadata, script_mode")
-        self.assertEqual(errors_list, ['No archive.dat file in the input_directory'],
+        self.assertEqual(input_dir, input_directory, "Problem with missing metadata, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with missing metadata, metadata_path")
+        self.assertEqual('preservation', script_mode, "Problem with missing metadata, script_mode")
+        self.assertEqual(['No archive.dat file in the input_directory'], errors_list,
                          "Problem with missing metadata, errors_list")
 
     def test_missing_one(self):
@@ -101,11 +101,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with missing one, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archive.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with missing one, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archive.dat'), metadata_path,
                          "Problem with missing one, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with missing one, script_mode")
-        self.assertEqual(errors_list, ['Missing one of the required arguments, input_directory or script_mode'],
+        self.assertEqual(None, script_mode, "Problem with missing one, script_mode")
+        self.assertEqual(['Missing one of the required arguments, input_directory or script_mode'], errors_list,
                          "Problem with missing one, errors_list")
 
     def test_too_many(self):
@@ -115,13 +115,13 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with too many, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with too many, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with too many, script_mode")
-        self.assertEqual(errors_list, ["Provided input_directory 'path_error' does not exist",
-                                       "Provided mode 'mode_error' is not 'access' or 'preservation'",
-                                       "Provided more than the required arguments, input_directory and script_mode"],
-                         "Problem with too many, errors_list")
+        self.assertEqual(None, input_directory, "Problem with too many, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with too many, metadata_path")
+        self.assertEqual(None, script_mode, "Problem with too many, script_mode")
+        self.assertEqual(["Provided input_directory 'path_error' does not exist",
+                          "Provided mode 'mode_error' is not 'access' or 'preservation'",
+                          "Provided more than the required arguments, input_directory and script_mode"],
+                         errors_list, "Problem with too many, errors_list")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_find_casework_rows.py
+++ b/tests/archival_office/test_find_casework_rows.py
@@ -44,11 +44,11 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'topic', 'subtopic', 'Casework'],
                     ['30602', 'type', 'topic', 'subtopic', 'SEND CASE TO ATL'],
                     ['30603', 'type', 'topic', 'subtopic', 'case']]
-        self.assertEqual(result, expected, "Problem with test for case - comments, df")
+        self.assertEqual(expected, result, "Problem with test for case - comments, df")
 
         # Tests the case remains log was not made.
         result = os.path.exists(os.path.join('test_data', 'case_remains_log.csv'))
-        self.assertEqual(result, False, "Problem with test for case - comments, case log")
+        self.assertEqual(False, result, "Problem with test for case - comments, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
@@ -57,7 +57,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'topic', 'subtopic', 'Casework'],
                     ['30602', 'type', 'topic', 'subtopic', 'SEND CASE TO ATL'],
                     ['30603', 'type', 'topic', 'subtopic', 'case']]
-        self.assertEqual(result, expected, "Problem with test for case - comments, delete log")
+        self.assertEqual(expected, result, "Problem with test for case - comments, delete log")
 
     def test_case_subtopic(self):
         """Test for when the column correspondence_subtopic contains the string "case" and is deleted"""
@@ -77,11 +77,11 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'topic', 'Casework', 'comments'],
                     ['30602', 'type', 'topic', 'NEW CASE SS', 'comments'],
                     ['30603', 'type', 'topic', 'case', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - subtopic, df")
+        self.assertEqual(expected, result, "Problem with test for case - subtopic, df")
 
         # Tests the case remains log was not made.
         result = os.path.exists(os.path.join('test_data', 'case_remains_log.csv'))
-        self.assertEqual(result, False, "Problem with test for case - subtopic, case log")
+        self.assertEqual(False, result, "Problem with test for case - subtopic, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
@@ -90,7 +90,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'topic', 'Casework', 'comments'],
                     ['30602', 'type', 'topic', 'NEW CASE SS', 'comments'],
                     ['30603', 'type', 'topic', 'case', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - subtopic, delete log")
+        self.assertEqual(expected, result, "Problem with test for case - subtopic, delete log")
 
     def test_case_topic(self):
         """Test for when the correspondence_topic contains the string "case" and is deleted"""
@@ -110,11 +110,11 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'Casework', 'subtopic', 'comments'],
                     ['30602', 'type', 'SEND CASE TO ATL', 'subtopic', 'comments'],
                     ['30603', 'type', 'case', 'subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - topic, df")
+        self.assertEqual(expected, result, "Problem with test for case - topic, df")
 
         # Tests the case remains log was not made.
         result = os.path.exists(os.path.join('test_data', 'case_remains_log.csv'))
-        self.assertEqual(result, False, "Problem with test for case - topic, case log")
+        self.assertEqual(False, result, "Problem with test for case - topic, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
@@ -123,7 +123,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'type', 'Casework', 'subtopic', 'comments'],
                     ['30602', 'type', 'SEND CASE TO ATL', 'subtopic', 'comments'],
                     ['30603', 'type', 'case', 'subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - topic, delete log")
+        self.assertEqual(expected, result, "Problem with test for case - topic, delete log")
 
     def test_case_type(self):
         """Test for when the column correspondence_type contains the string "case" and is deleted"""
@@ -141,11 +141,11 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'CASE', 'topic', 'subtopic', 'comments'],
                     ['30601', 'Casework', 'topic', 'subtopic', 'comments'],
                     ['30602', 'legal case', 'topic', 'subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - type, df")
+        self.assertEqual(expected, result, "Problem with test for case - type, df")
 
         # Tests the case remains log was not made.
         result = os.path.exists(os.path.join('test_data', 'case_remains_log.csv'))
-        self.assertEqual(result, False, "Problem with test for case - type, case log")
+        self.assertEqual(False, result, "Problem with test for case - type, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
@@ -153,7 +153,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'CASE', 'topic', 'subtopic', 'comments'],
                     ['30601', 'Casework', 'topic', 'subtopic', 'comments'],
                     ['30602', 'legal case', 'topic', 'subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for case - type, delete log")
+        self.assertEqual(expected, result, "Problem with test for case - type, delete log")
 
     def test_casework_some(self):
         """Test for when some rows contain the string case and are deleted, and one row is not"""
@@ -176,11 +176,11 @@ class MyTestCase(unittest.TestCase):
                     ['30602', 'ITEM', 'OF-GEN, CASE', '', 'NOTE'],
                     ['30603', 'ITEM', 'OF-GEN', 'Legal Case', ''],
                     ['30604', 'ITEM', 'TR-RAL', '', 'SENT TO CASE WORK, ATL']]
-        self.assertEqual(result, expected, "Problem with test for casework - some, df")
+        self.assertEqual(expected, result, "Problem with test for casework - some, df")
 
         # Tests the case remains log was not made.
         result = os.path.exists(os.path.join('test_data', 'case_remains_log.csv'))
-        self.assertEqual(result, False, "Problem with test for casework - some, case log")
+        self.assertEqual(False, result, "Problem with test for casework - some, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
@@ -190,7 +190,7 @@ class MyTestCase(unittest.TestCase):
                     ['30602', 'ITEM', 'OF-GEN, CASE', 'nan', 'NOTE'],
                     ['30603', 'ITEM', 'OF-GEN', 'Legal Case', 'nan'],
                     ['30604', 'ITEM', 'TR-RAL', 'nan', 'SENT TO CASE WORK, ATL']]
-        self.assertEqual(result, expected, "Problem with test for casework - some, delete log")
+        self.assertEqual(expected, result, "Problem with test for casework - some, delete log")
 
     def test_no_casework(self):
         """Test for when none of the tested columns contain the string case and nothing is deleted"""
@@ -205,19 +205,19 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in the returned dataframe are correct.
         result = df_to_list(casework_df)
         expected = [['city', 'correspondence_type', 'correspondence_topic', 'correspondence_subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for no casework, df")
+        self.assertEqual(expected, result, "Problem with test for no casework, df")
 
         # Tests the values in the case remains log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_remains_log.csv'))
         expected = [['city', 'correspondence_type', 'correspondence_topic', 'correspondence_subtopic', 'comments'],
                     ['CASEYVILLE', 'ITEM', 'PR', 'nan', 'I AM ON IT'],
                     ['CASE', 'ITEM', 'TR-RAL', 'nan', 'NOTE']]
-        self.assertEqual(result, expected, "Problem with test for no casework, case log")
+        self.assertEqual(expected, result, "Problem with test for no casework, case log")
 
         # Tests the values in the case delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'case_delete_log.csv'))
         expected = [['city', 'correspondence_type', 'correspondence_topic', 'correspondence_subtopic', 'comments']]
-        self.assertEqual(result, expected, "Problem with test for no casework, delete log")
+        self.assertEqual(expected, result, "Problem with test for no casework, delete log")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_read_metadata.py
+++ b/tests/archival_office/test_read_metadata.py
@@ -22,7 +22,7 @@ class MyTestCase(unittest.TestCase):
                      'CASE', 'TR-HWY', '', '', 'RA', '555QRS667', 'ANOTHER NOTE'],
                     ['LAST B, FIRST B MIDDLE, JR.', '', '', '200 ROAD', 'APT 5B', 'CITY A', 'GA', '30001',
                      'ISSUE', 'TR-RAL', '', '980104', 'NOP', '', '']]
-        self.assertEqual(result, expected, "Problem with test for blank rows")
+        self.assertEqual(expected, result, "Problem with test for blank rows")
 
     def test_no_blank(self):
         """Test for when the metadata file has no blank rows"""
@@ -42,7 +42,7 @@ class MyTestCase(unittest.TestCase):
                      'CASE', 'TR-HWY', '', '', 'RA', '555QRS667', 'ANOTHER NOTE'],
                     ['LAST B, FIRST B MIDDLE, JR.', '', '', '200 ROAD', 'APT 5B', 'CITY A', 'GA', '30001',
                      'ISSUE', 'TR-RAL', '', '980104', 'NOP', '', '']]
-        self.assertEqual(result, expected, "Problem with test for no blank rows")
+        self.assertEqual(expected, result, "Problem with test for no blank rows")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_remove_casework_letters.py
+++ b/tests/archival_office/test_remove_casework_letters.py
@@ -47,12 +47,12 @@ class MyTestCase(unittest.TestCase):
                      '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework'],
                     [os.path.join(input_directory, 'text', '300003.txt'),
                      '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for deletion, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for deletion, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for deletion, directory contents")
+        self.assertEqual(expected, result, "Problem with test for deletion, directory contents")
 
     def test_file_not_found(self):
         """Test for when the files in the metadata deletion log are not present in the export"""
@@ -70,12 +70,12 @@ class MyTestCase(unittest.TestCase):
                      'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError'],
                     [os.path.join(input_directory, 'text', '50.txt'),
                      'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for file not found, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for file not found, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['100001.txt', 'ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for file not found, directory contents")
+        self.assertEqual(expected, result, "Problem with test for file not found, directory contents")
 
     def test_no_deletion(self):
         """Test for when there is a metadata deletion log but no rows have an associated file"""
@@ -86,12 +86,12 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the file deletion log was not made.
         result = os.path.exists(os.path.join(output_dir, f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        self.assertEqual(result, False, "Problem with test for no deletion, file deletion log")
+        self.assertEqual(False, result, "Problem with test for no deletion, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for no deletion, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no deletion, directory contents")
 
     def test_no_log(self):
         """Test for when there is no metadata deletion log"""
@@ -102,12 +102,12 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the file deletion log was not made.
         result = os.path.exists(os.path.join(output_dir, f"file_deletion_log_{date.today().strftime('%Y-%m-%d')}.csv"))
-        self.assertEqual(result, False, "Problem with test for no log, file deletion log")
+        self.assertEqual(False, result, "Problem with test for no log, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for no log, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no log, directory contents")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_remove_casework_letters.py
+++ b/tests/archival_office/test_remove_casework_letters.py
@@ -42,11 +42,11 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [os.path.join(input_directory, 'text', '100001.txt'),
-                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'casework'],
+                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework'],
                     [os.path.join(input_directory, 'text', '200002.txt'),
-                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'casework'],
+                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework'],
                     [os.path.join(input_directory, 'text', '300003.txt'),
-                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'casework']]
+                     '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework']]
         self.assertEqual(result, expected, "Problem with test for deletion, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.

--- a/tests/archival_office/test_remove_casework_rows.py
+++ b/tests/archival_office/test_remove_casework_rows.py
@@ -28,7 +28,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['state_code', 'zip_code', 'comments'],
                     ['GA', 30601, 'info'],
                     ['GA', 30603, 'other info']]
-        self.assertEqual(result, expected, "Problem with test for function")
+        self.assertEqual(expected, result, "Problem with test for function")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_remove_pii.py
+++ b/tests/archival_office/test_remove_pii.py
@@ -24,11 +24,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the columns of the returned dataframe are correct.
         expected = ['city', 'state_code', 'zip_code', 'correspondence_type', 'correspondence_topic',
                     'correspondence_subtopic', 'letter_date', 'staffer_initials', 'document_number', 'comments']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for function, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for function, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['6', '7', '8', '9', '10', '11', '12', '13', '14', '15']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for function, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for function, values")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_script.py
+++ b/tests/archival_office/test_script.py
@@ -67,12 +67,12 @@ class MyTestCase(unittest.TestCase):
                      'ISSUE', 'CASE', 'nan', '970813', 'FWIW', '725SAT100', 'Q111111'],
                     ['nan', 'CEO', 'START UP Z', '444 BROAD ST', 'nan', 'ATLANTA', 'GA', '30002', 'ISSUE', 'CASE',
                      'nan', 'nan', 'FWIW', 'nan', 'Q444444']]
-        self.assertEqual(result, expected, "Problem with test for access, case delete log")
+        self.assertEqual(expected, result, "Problem with test for access, case delete log")
 
         # Tests the case remains log was not made.
         csv_path = os.path.join(output_directory, 'case_remains_log.csv')
         result = os.path.exists(csv_path)
-        self.assertEqual(result, False, "Problem with test for access, case remains log")
+        self.assertEqual(False, result, "Problem with test for access, case remains log")
 
         # Tests the contents of archive_redacted.csv.
         csv_path = os.path.join(output_directory, 'archive_redacted.csv')
@@ -86,7 +86,7 @@ class MyTestCase(unittest.TestCase):
                      'A COMMENT THAT IS AS LONG AS IS PERMITTED BY THE FIELD LENGTH FOR THE COMMENTS COLUMN, '
                      'THE LAST ONE'],
                     ['COLUMBUS', 'GA', '30003', 'ISSUE', 'AG-TOB', 'ABC', '980113', 'TBD', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, archive_redacted.csv")
+        self.assertEqual(expected, result, "Problem with test for access, archive_redacted.csv")
 
         # Tests the contents of 1997-1998.csv.
         csv_path = os.path.join(output_directory, '1997-1998.csv')
@@ -97,7 +97,7 @@ class MyTestCase(unittest.TestCase):
                     ['CAIRO', 'GA', '30001', 'ISSUE', 'nan', 'nan', '980801', 'TBD', 'nan', 'nan'],
                     ['ATLANTA', 'GA', '30000-0001', 'ISSUE', 'TD-GEN', 'nan', '971001', 'FWIW', '725SAT101', 'nan'],
                     ['COLUMBUS', 'GA', '30003', 'ISSUE', 'AG-TOB', 'ABC', '980113', 'TBD', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for access, 1997-1998")
 
         # Tests the contents of undated.csv.
         csv_path = os.path.join(output_directory, 'undated.csv')
@@ -107,7 +107,7 @@ class MyTestCase(unittest.TestCase):
                     ['ATLANTA', 'GA', '30002', 'ISSUE', 'nan', 'nan', 'nan', 'FWIW', 'nan',
                      'A COMMENT THAT IS AS LONG AS IS PERMITTED BY THE FIELD LENGTH FOR THE COMMENTS COLUMN, '
                      'THE LAST ONE']]
-        self.assertEqual(result, expected, "Problem with test for access, undated")
+        self.assertEqual(expected, result, "Problem with test for access, undated")
 
     def test_error_argument(self):
         """Test for when the script exits due to an argument error."""
@@ -121,7 +121,7 @@ class MyTestCase(unittest.TestCase):
         output = subprocess.run(f"python {script_path}", shell=True, stdout=subprocess.PIPE)
         result = output.stdout.decode('utf-8')
         expected = "Missing required arguments, input_directory and script_mode\r\n"
-        self.assertEqual(result, expected, "Problem with test for error argument, printed error")
+        self.assertEqual(expected, result, "Problem with test for error argument, printed error")
 
     def test_preservation(self):
         """Test for when the script runs in preservation mode."""
@@ -149,7 +149,7 @@ class MyTestCase(unittest.TestCase):
                      'nan', 'nan', 'FWIW', 'nan', 'Q444444'],
                     ['Zayne', 'nan', 'nan', '456 Street', 'nan', 'ATLANTA', 'GA', '30004', 'ISSUE', 'CASE', 'nan',
                      '980113', 'TBD', 'nan', 'Q000000']]
-        self.assertEqual(result, expected, "Problem with test for preservation, case delete log")
+        self.assertEqual(expected, result, "Problem with test for preservation, case delete log")
 
         # Tests the contents of the case remains log.
         csv_path = os.path.join(output_directory, 'case_remains_log.csv')
@@ -159,7 +159,7 @@ class MyTestCase(unittest.TestCase):
                      'letter_date', 'staffer_initials', 'document_number', 'comments'],
                     ['SMITH', 'nan', 'AN INSTITUTE', 'PO BOX 123', '1000 MAIN', 'CASEYVILLE', 'GA', '30003', 'ISSUE',
                      'AG-TOB', 'ABC', '980113', 'TBD', 'nan', 'Comment']]
-        self.assertEqual(result, expected, "Problem with test for preservation, case remains log")
+        self.assertEqual(expected, result, "Problem with test for preservation, case remains log")
 
         # Tests the contents of the file deletion log.
         csv_path = os.path.join(output_directory, f"file_deletion_log_{today}.csv")
@@ -171,12 +171,12 @@ class MyTestCase(unittest.TestCase):
                      'C29C5262DF8A6B0072322ED6942BE134', 'casework'],
                     [os.path.join(input_directory, 'text', '000000.txt'), 'nan', 'nan', 'nan', 'nan',
                      'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for preservation, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for preservation, file deletion log")
 
         # Tests the correct files were deleted.
         result = files_in_dir(os.path.join(input_directory, 'text'))
         expected = ['222222.txt', '333333.txt', '555555.txt', 'ED55-1.txt', 'F01-11.txt']
-        self.assertEqual(result, expected, "Problem with test for preservation, files deleted")
+        self.assertEqual(expected, result, "Problem with test for preservation, files deleted")
 
 
 if __name__ == '__main__':

--- a/tests/archival_office/test_split_congress_year.py
+++ b/tests/archival_office/test_split_congress_year.py
@@ -38,27 +38,27 @@ class MyTestCase(unittest.TestCase):
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ATLANTA', 'TX-GEN', '970102', 'AC'],
                     ['RIVERDALE', 'FR-GEN', '980505', 'AC']]
-        self.assertEqual(result, expected, "Problem with test for all years, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for all years, 1997-1998")
 
         # Tests that 1999-2000.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1999-2000.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ATLANTA', 'EV-WAT', '990719', 'VT'],
                     ['ROSWELL', 'nan', '001031', 'TGO']]
-        self.assertEqual(result, expected, "Problem with test for all years, 1999-2000")
+        self.assertEqual(expected, result, "Problem with test for all years, 1999-2000")
 
         # Tests that 2003-2004.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '2003-2004.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['COLUMBUS', 'TX-GEN', '030315', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for all years, 2003-2004")
+        self.assertEqual(expected, result, "Problem with test for all years, 2003-2004")
 
         # Tests that undated.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'undated.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['LAWRENCEVILLE', 'FR-GEN', 'nan', 'AC'],
                     ['LAWRENCEVILLE', 'CO-OLD', 'nan', 'VT']]
-        self.assertEqual(result, expected, "Problem with test for all years, undated")
+        self.assertEqual(expected, result, "Problem with test for all years, undated")
 
     def test_blank(self):
         """Test for when some of the letters do not have a date (letter_date column is empty string)"""
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
                     ['ROSWELL', 'nan', 'nan', 'TGO'],
                     ['COLUMBUS', 'TX-GEN', 'nan', 'nan'],
                     ['LAWRENCEVILLE', 'CO-OLD', 'nan', 'VT']]
-        self.assertEqual(result, expected, "Problem with test for blank, undated")
+        self.assertEqual(expected, result, "Problem with test for blank, undated")
 
     def test_1900s(self):
         """Test for when the years are from the 1900s (two-digit year is 60 or later)"""
@@ -92,18 +92,18 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(os.path.join('test_data', '1959-1960.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ATLANTA', 'EV-WAT', '600719', 'VT']]
-        self.assertEqual(result, expected, "Problem with test for 1900S, 1959-1960")
+        self.assertEqual(expected, result, "Problem with test for 1900S, 1959-1960")
 
         # Tests that 1997-1998.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '1997-1998.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ATLANTA', 'TX-GEN', '970102', 'AC'],
                     ['RIVERDALE', 'FR-GEN', '980505', 'AC']]
-        self.assertEqual(result, expected, "Problem with test for 1900S, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for 1900S, 1997-1998")
 
         # Tests that undated.csv was not made.
         result = os.path.exists(os.path.join('test_data', 'undated.csv'))
-        self.assertEqual(result, False, "Problem with test for 1900s, undated")
+        self.assertEqual(False, result, "Problem with test for 1900s, undated")
 
     def test_2000s(self):
         """Test for when the years are from the 2000s (two-digit year is 59 or earlier"""
@@ -119,23 +119,23 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(os.path.join('test_data', '1999-2000.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ROSWELL', 'nan', '001031', 'TGO']]
-        self.assertEqual(result, expected, "Problem with test for 2000s, 1999-2000")
+        self.assertEqual(expected, result, "Problem with test for 2000s, 1999-2000")
 
         # Tests that 2001-2002.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '2001-2002.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['COLUMBUS', 'TX-GEN', '010315', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for 2000s, 2001-2002")
+        self.assertEqual(expected, result, "Problem with test for 2000s, 2001-2002")
 
         # Tests that 2059-2060.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', '2059-2060.csv'))
         expected = [['city', 'correspondence_topic', 'letter_date', 'staffer_initials'],
                     ['ATLANTA', 'TX-GEN', '590102', 'AC']]
-        self.assertEqual(result, expected, "Problem with test for 2000s, 2059-2060")
+        self.assertEqual(expected, result, "Problem with test for 2000s, 2059-2060")
 
         # Tests that undated.csv was not made.
         result = os.path.exists(os.path.join('test_data', 'undated.csv'))
-        self.assertEqual(result, False, "Problem with test for 2000s, undated")
+        self.assertEqual(False, result, "Problem with test for 2000s, undated")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_appraisal_check_df.py
+++ b/tests/cms_data_interchange_format/test_appraisal_check_df.py
@@ -25,7 +25,7 @@ class MyTestCase(unittest.TestCase):
                      'Appraisal_Category'],
                     ['20230101', r'doc\legal case.txt', 'Concern re doe case', 'court > case', 'Casework'],
                     ['20230202', r'doc\CASE.txt', 'POSSIBLE CASE', 'admin', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for multiple columns")
+        self.assertEqual(expected, result, "Problem with test for multiple columns")
 
     def test_one(self):
         """ Test for when the keyword is in one column"""
@@ -48,7 +48,7 @@ class MyTestCase(unittest.TestCase):
                     ['20230303', r'doc\CASE_FILE.txt', 'note3', 'admin', 'Casework'],
                     ['20230404', r'doc\file4.txt', 'case', 'general', 'Casework'],
                     ['20230405', r'doc\file5.txt', 'note5', 'court > case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one column")
+        self.assertEqual(expected, result, "Problem with test for one column")
 
     def test_none(self):
         """ Test for when the keyword is not in any column"""
@@ -63,7 +63,7 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_check)
         expected = [['date_in', 'correspondence_document_name', 'correspondence_text', 'code_description',
                      'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no match for appraisal)")
+        self.assertEqual(expected, result, "Problem with test for none (no match for appraisal)")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_check_arguments.py
+++ b/tests/cms_data_interchange_format/test_check_arguments.py
@@ -24,10 +24,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - access, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - access, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with correct - access, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - access, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - access, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with correct - access, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - access, errors_list")
 
     def test_correct_accession(self):
         """Test for when both required arguments are present, input_directory path exists and
@@ -44,10 +44,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - accession, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - accession, metadata_paths_dict")
-        self.assertEqual(script_mode, 'accession', "Problem with correct - accession, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - accession, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - accession, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - accession, metadata_paths_dict")
+        self.assertEqual('accession', script_mode, "Problem with correct - accession, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - accession, errors_list")
 
     def test_correct_appraisal(self):
         """Test for when both required arguments are present, input_directory path exists and
@@ -64,10 +64,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - appraisal, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - appraisal, metadata_paths_dict")
-        self.assertEqual(script_mode, 'appraisal', "Problem with correct - appraisal, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - appraisal, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - appraisal, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - appraisal, metadata_paths_dict")
+        self.assertEqual('appraisal', script_mode, "Problem with correct - appraisal, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - appraisal, errors_list")
 
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists and 
@@ -84,10 +84,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - preservation, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - preservation, metadata_paths_dict")
-        self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - preservation, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - preservation, metadata_paths_dict")
+        self.assertEqual('preservation', script_mode, "Problem with correct - preservation, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - preservation, errors_list")
 
     def test_error_input_directory(self):
         """Test for when the input_directory path does not exist"""
@@ -97,10 +97,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with error - input directory, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with error - input directory, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with error - input directory, script_mode")
-        self.assertEqual(errors_list, [f"Provided input_directory '{input_dir}' does not exist"],
+        self.assertEqual(None, input_directory, "Problem with error - input directory, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with error - input directory, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with error - input directory, script_mode")
+        self.assertEqual([f"Provided input_directory '{input_dir}' does not exist"], errors_list,
                          "Problem with error - input directory, errors_list")
 
     def test_error_script_mode(self):
@@ -117,10 +117,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with error - script mode, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with error - script mode, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with error - script mode, script_mode")
-        self.assertEqual(errors_list, ["Provided mode 'mode_error' is not one of the expected modes"],
+        self.assertEqual(input_dir, input_directory, "Problem with error - script mode, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with error - script mode, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with error - script mode, script_mode")
+        self.assertEqual(["Provided mode 'mode_error' is not one of the expected modes"], errors_list,
                          "Problem with error - script mode, errors_list")
 
     def test_missing_both_arg(self):
@@ -130,10 +130,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with missing both arguments, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with missing both arguments, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with missing both arguments, script_mode")
-        self.assertEqual(errors_list, ["Missing required arguments, input_directory and script_mode"],
+        self.assertEqual(None, input_directory, "Problem with missing both arguments, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with missing both arguments, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with missing both arguments, script_mode")
+        self.assertEqual(["Missing required arguments, input_directory and script_mode"], errors_list,
                          "Problem with missing both arguments, errors_list")
 
     def test_missing_metadata(self):
@@ -144,16 +144,16 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with missing metadata, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with missing metadata, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with missing metadata, script_mode")
-        self.assertEqual(errors_list, ['No 1B.out file in the input_directory',
-                                       'No 2A.out file in the input_directory',
-                                       'No 2B.out file in the input_directory',
-                                       'No 2C.out file in the input_directory',
-                                       'No 2D.out file in the input_directory',
-                                       'No 8A.out file in the input_directory'],
-                         "Problem with missing metadata, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with missing metadata, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with missing metadata, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with missing metadata, script_mode")
+        self.assertEqual(['No 1B.out file in the input_directory',
+                          'No 2A.out file in the input_directory',
+                          'No 2B.out file in the input_directory',
+                          'No 2C.out file in the input_directory',
+                          'No 2D.out file in the input_directory',
+                          'No 8A.out file in the input_directory'],
+                         errors_list, "Problem with missing metadata, errors_list")
 
     def test_missing_metadata_some(self):
         """Test for when some metadata files are in the input_directory"""
@@ -166,13 +166,13 @@ class MyTestCase(unittest.TestCase):
         expected_dict = {'2A': os.path.join(input_dir, '2A.out'),
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with missing metadata - some, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with missing metadata - some, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with missing metadata - some, script_mode")
-        self.assertEqual(errors_list, ['No 1B.out file in the input_directory',
-                                       'No 2B.out file in the input_directory',
-                                       'No 8A.out file in the input_directory'],
-                         "Problem with missing metadata - some, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with missing metadata - some, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with missing metadata - some, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with missing metadata - some, script_mode")
+        self.assertEqual(['No 1B.out file in the input_directory',
+                          'No 2B.out file in the input_directory',
+                          'No 8A.out file in the input_directory'],
+                         errors_list, "Problem with missing metadata - some, errors_list")
 
     def test_missing_one_arg(self):
         """Test for when one required argument (script_mode) is missing"""
@@ -188,10 +188,10 @@ class MyTestCase(unittest.TestCase):
                          '2C': os.path.join(input_dir, '2C.out'),
                          '2D': os.path.join(input_dir, '2D.out'),
                          '8A': os.path.join(input_dir, '8A.out')}
-        self.assertEqual(input_directory, input_dir, "Problem with missing one argument, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with missing one argument, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with missing one argument, script_mode")
-        self.assertEqual(errors_list, ["Missing one of the required arguments, input_directory or script_mode"],
+        self.assertEqual(input_dir, input_directory, "Problem with missing one argument, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with missing one argument, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with missing one argument, script_mode")
+        self.assertEqual(["Missing one of the required arguments, input_directory or script_mode"], errors_list,
                          "Problem with missing one argument, errors_list")
 
     def test_too_many_arg(self):
@@ -202,13 +202,13 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with too many arguments, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with too many arguments, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with too many arguments, script_mode")
-        self.assertEqual(errors_list, [f"Provided input_directory '{input_dir}' does not exist",
-                                       "Provided mode 'mode_error' is not one of the expected modes",
-                                       "Provided more than the required arguments, input_directory and script_mode"],
-                         "Problem with too many arguments, errors_list")
+        self.assertEqual(None, input_directory, "Problem with too many arguments, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with too many arguments, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with too many arguments, script_mode")
+        self.assertEqual([f"Provided input_directory '{input_dir}' does not exist",
+                          "Provided mode 'mode_error' is not one of the expected modes",
+                          "Provided more than the required arguments, input_directory and script_mode"],
+                         errors_list, "Problem with too many arguments, errors_list")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_check_letter_matching.py
+++ b/tests/cms_data_interchange_format/test_check_letter_matching.py
@@ -40,7 +40,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '2', '33%'],
                     ['Metadata_Blank', '1', '17%'],
                     ['Directory_Only', '3', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for all, matching csv")
+        self.assertEqual(expected, result, "Problem with test for all, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
@@ -50,7 +50,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', f'{input_directory.lower()}\\documents\\in-email\\part_two\\3.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\forms\\extra.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\in-email\\extra.txt'],]
-        self.assertEqual(result, expected, "Problem with test for all, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for all, matching details csv")
 
     def test_blanks(self):
         """Test for when the document column includes blanks"""
@@ -74,12 +74,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '9', '60%'],
                     ['Directory_Only', '0', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for blanks, matching csv")
+        self.assertEqual(expected, result, "Problem with test for blanks, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for blanks, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for blanks, matching details csv")
 
     def test_directory_only(self):
         """Test for when some file paths are in the directory but not the metadata"""
@@ -98,7 +98,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '3', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, matching csv")
+        self.assertEqual(expected, result, "Problem with test for directory_only, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
@@ -106,7 +106,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', f'{input_directory.lower()}\\documents\\forms\\2.txt'],
                     ['Directory Only', f'{input_directory.lower()}\\documents\\in-email\\part_one\\1.txt'],
                     ['Directory Only', f'{input_directory.lower()}\\documents\\in-email\\part_two\\3.txt']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for directory_only, matching details csv")
 
     def test_duplicates(self):
         """Test for when the document column includes duplicates, which are not counted"""
@@ -130,12 +130,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for duplicates, matching csv")
+        self.assertEqual(expected, result, "Problem with test for duplicates, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for duplicates, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for duplicates, matching details csv")
 
     def test_match(self):
         """Test for when the document column matches the directory contents, with some case differences"""
@@ -156,12 +156,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for match, matching csv")
+        self.assertEqual(expected, result, "Problem with test for match, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for match, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for match, matching details csv")
 
     def test_metadata_only(self):
         """Test for when some file paths are in the metadata but not the directory"""
@@ -183,14 +183,14 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '2', '25%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, matching csv")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, matching csv")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
         expected = [['Category', 'Path'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\documents\\1.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\forms\\extra.txt']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, matching details csv")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, matching details csv")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_check_metadata_formatting.py
+++ b/tests/cms_data_interchange_format/test_check_metadata_formatting.py
@@ -44,11 +44,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 'column_blank', "Problem with test for column_blank, count")
+        self.assertEqual('column_blank', zip_mismatch, "Problem with test for column_blank, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_blank, report")
+        self.assertEqual(False, result, "Problem with test for column_blank, report")
 
     def test_column_missing(self):
         """Test for a column that is missing, which would be the same for any column"""
@@ -61,11 +61,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 'column_missing', "Problem with test for column_missing, count")
+        self.assertEqual('column_missing', zip_mismatch, "Problem with test for column_missing, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_missing, report")
+        self.assertEqual(False, result, "Problem with test for column_missing, report")
 
     def test_column_no_errors(self):
         """Test for a column with no formatting errors, which would be the same for any column"""
@@ -77,11 +77,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 0, "Problem with test for column_no_errors, count")
+        self.assertEqual(0, zip_mismatch, "Problem with test for column_no_errors, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_no_errors, report")
+        self.assertEqual(False, result, "Problem with test for column_no_errors, report")
 
     def test_correspondence_document_name(self):
         """Test for the correspondence_document_name column"""
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
         cdm_mismatch = check_metadata_formatting('correspondence_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(cdm_mismatch, 3, "Problem with test for correspondence_document_name, count")
+        self.assertEqual(3, cdm_mismatch, "Problem with test for correspondence_document_name, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv'))
@@ -120,7 +120,7 @@ class MyTestCase(unittest.TestCase):
         date_in_mismatch = check_metadata_formatting('date_in', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(date_in_mismatch, 3, "Problem with test for date_in, count")
+        self.assertEqual(3, date_in_mismatch, "Problem with test for date_in, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_date_in.csv'))
@@ -129,7 +129,7 @@ class MyTestCase(unittest.TestCase):
                     ['BLANK', 'BLANK', '2005', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['BLANK', 'BLANK', '2005-01-02', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['BLANK', 'BLANK', 'January 2005', 'BLANK', 'BLANK', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for date_in, report")
+        self.assertEqual(expected, result, "Problem with test for date_in, report")
 
     def test_date_out(self):
         """Test for the date_out column"""
@@ -152,7 +152,7 @@ class MyTestCase(unittest.TestCase):
                      'correspondence_document_name'],
                     ['BLANK', 'BLANK', 'BLANK', '2025/12/01', 'BLANK', 'BLANK', 'BLANK'],
                     ['BLANK', 'BLANK', 'BLANK', '2025-12-01', 'BLANK', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for date_out, report")
+        self.assertEqual(expected, result, "Problem with test for date_out, report")
 
     def test_tickler_date(self):
         """Test for the tickler_date column"""
@@ -167,14 +167,14 @@ class MyTestCase(unittest.TestCase):
         reminder_mismatch = check_metadata_formatting('tickler_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(reminder_mismatch, 1, "Problem with test for tickler_date, count")
+        self.assertEqual(1, reminder_mismatch, "Problem with test for tickler_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_tickler_date.csv'))
         expected = [['state', 'zip_code', 'date_in', 'date_out', 'tickler_date', 'update_date',
                      'correspondence_document_name'],
                     ['BLANK', 'BLANK', 'BLANK', 'BLANK', '2023', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for tickler_date, report")
+        self.assertEqual(expected, result, "Problem with test for tickler_date, report")
 
     def test_state(self):
         """Test for the state column"""
@@ -189,7 +189,7 @@ class MyTestCase(unittest.TestCase):
         state_mismatch = check_metadata_formatting('state', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 3, "Problem with test for state, count")
+        self.assertEqual(3, state_mismatch, "Problem with test for state, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_state.csv'))
@@ -198,7 +198,7 @@ class MyTestCase(unittest.TestCase):
                     ['ga', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['Georgia', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['X', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for state, report")
+        self.assertEqual(expected, result, "Problem with test for state, report")
 
     def test_update_date(self):
         """Test for the update_date column"""
@@ -213,7 +213,7 @@ class MyTestCase(unittest.TestCase):
         update_mismatch = check_metadata_formatting('update_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(update_mismatch, 2, "Problem with test for update_date, count")
+        self.assertEqual(2, update_mismatch, "Problem with test for update_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv'))
@@ -221,7 +221,7 @@ class MyTestCase(unittest.TestCase):
                      'correspondence_document_name'],
                     ['BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', '202101212', 'BLANK'],
                     ['BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'no date', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for update_date, report")
+        self.assertEqual(expected, result, "Problem with test for update_date, report")
 
     def test_zip_code(self):
         """Test for the zip_code column"""
@@ -236,7 +236,7 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 3, "Problem with test for zip_code, count")
+        self.assertEqual(3, zip_mismatch, "Problem with test for zip_code, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
@@ -245,7 +245,7 @@ class MyTestCase(unittest.TestCase):
                     ['BLANK', '30601 1234', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['BLANK', '3060', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['BLANK', 'XXXXX', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for zip_code, report")
+        self.assertEqual(expected, result, "Problem with test for zip_code, report")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_check_metadata_usability.py
+++ b/tests/cms_data_interchange_format/test_check_metadata_usability.py
@@ -73,7 +73,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '0', '0.0', 'uncheckable'],
                     ['code_description', 'True', '0', '0.0', 'uncheckable'],
                     ['inactive_flag', 'True', '0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for all correct, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for all correct, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -84,7 +84,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for all correct, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for all correct, metadata_formatting_errors csvs")
 
     def test_blank(self):
         """Test for when every row is blank"""
@@ -120,7 +120,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '2', '100.0', 'uncheckable'],
                     ['code_description', 'True', '2', '100.0', 'uncheckable'],
                     ['inactive_flag', 'True', '2', '100.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for blank, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for blank, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -131,7 +131,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for all blank, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for all blank, metadata_formatting_errors csvs")
 
     def test_blank_partial(self):
         """Test for some rows of each column have blanks but no column is entirely blank"""
@@ -173,7 +173,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '3', '60.0', 'uncheckable'],
                     ['code_description', 'True', '4', '80.0', 'uncheckable'],
                     ['inactive_flag', 'True', '1', '20.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for blank_partial, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for blank_partial, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -184,7 +184,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for blank_partial, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for blank_partial, metadata_formatting_errors csvs")
 
     def test_columns_extra(self):
         """Test for when there are additional columns beyond what is expected"""
@@ -226,7 +226,7 @@ class MyTestCase(unittest.TestCase):
                     ['tickler_date', 'True', '0', '0.0', '0'],
                     ['update_date', 'True', '0', '0.0', '0'],
                     ['zip_code', 'True', '0', '0.0', '0']]
-        self.assertEqual(result, expected, "Problem with test for columns_extra, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for columns_extra, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -237,7 +237,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for columns_metadata, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for columns_metadata, metadata_formatting_errors csvs")
 
     def test_columns_missing(self):
         """Test for when every column except dates is missing
@@ -273,7 +273,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'False', 'BLANK', 'BLANK', 'uncheckable'],
                     ['code_description', 'False', 'BLANK', 'BLANK', 'uncheckable'],
                     ['inactive_flag', 'False', 'BLANK', 'BLANK', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for columns_missing, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for columns_missing, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -284,7 +284,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for columns_missing, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for columns_missing, metadata_formatting_errors csvs")
 
     def test_columns_missing_dates(self):
         """Test for when the date columns are missing
@@ -324,7 +324,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '0.0', '0.0', 'uncheckable'],
                     ['code_description', 'True', '0.0', '0.0', 'uncheckable'],
                     ['inactive_flag', 'True', '0.0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for columns_missing_dates, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for columns_missing_dates, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -335,7 +335,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for columns_missing_datest, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for columns_missing_datest, metadata_formatting_errors csvs")
 
     def test_formatting(self):
         """Test for when each column with formatting tests has errors"""
@@ -373,7 +373,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '0', '0.0', 'uncheckable'],
                     ['code_description', 'True', '0', '0.0', 'uncheckable'],
                     ['inactive_flag', 'True', '0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for formatting, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for formatting, usability_report_metadata.csv")
 
         # Tests which formatting reports were made, if any.
         result = [os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_correspondence_document_name.csv')),
@@ -384,7 +384,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv')),
                   os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))]
         expected = [True, True, True, True, True, True, True]
-        self.assertEqual(result, expected, "Problem with test for formatting, metadata_formatting_errors csvs")
+        self.assertEqual(expected, result, "Problem with test for formatting, metadata_formatting_errors csvs")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_delete_appraisal_letters.py
+++ b/tests/cms_data_interchange_format/test_delete_appraisal_letters.py
@@ -1,5 +1,5 @@
 """
-Tests for the function delete_appraisal_letters(), which deletes letters for appraisal reasons.
+Tests for the function delete_appraisal_letters(), which deletes letters for appraisal reaassertEqual(expected, resultns.
 To simplify input, the test uses dataframes with only a few of the columns present in a real export.
 """
 from datetime import date
@@ -56,12 +56,12 @@ class MyTestCase(unittest.TestCase):
                      '0.6', today, today, '6CF993E723D5AD2B841A303056E0535B', 'Academy_Application'],
                     [os.path.join(input_directory, 'documents', 'out-custom', '1002.txt'),
                      '2.8', today, today, '2F48B70AB29E2B466768B6897A1640E2', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for delete, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for delete, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1.txt', '3.txt']
-        self.assertEqual(result, expected, "Problem with test for delete, directory contents")
+        self.assertEqual(expected, result, "Problem with test for delete, directory contents")
 
     def test_error_filenotfound(self):
         """Test for when the file paths in the metadata do not match files in the export"""
@@ -82,12 +82,12 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [os.path.join(input_directory, 'documents', 'out-custom', '1.txt'),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for error_filenotfound, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for error_filenotfound, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1.txt']
-        self.assertEqual(result, expected, "Problem with test for error_filenotfound, directory contents")
+        self.assertEqual(expected, result, "Problem with test for error_filenotfound, directory contents")
 
     def test_error_new(self):
         """Test for when the file paths in the metadata are a new pattern"""
@@ -108,12 +108,12 @@ class MyTestCase(unittest.TestCase):
                     'Cannot determine file path: new path pattern in metadata'],
                     ['new_folder\\1001.txt', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'Cannot determine file path: new path pattern in metadata']]
-        self.assertEqual(result, expected, "Problem with test for error_new, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for error_new, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1.txt']
-        self.assertEqual(result, expected, "Problem with test for error_new, directory contents")
+        self.assertEqual(expected, result, "Problem with test for error_new, directory contents")
 
     def test_skip_blank(self):
         """Test for when the file paths in the metadata are blank"""
@@ -130,12 +130,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for skip_blank, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for skip_blank, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1000.txt', '1001.txt']
-        self.assertEqual(result, expected, "Problem with test for skip_blank, directory contents")
+        self.assertEqual(expected, result, "Problem with test for skip_blank, directory contents")
 
     def test_skip_empty_string(self):
         """Test for when the file paths in the metadata are empty strings"""
@@ -152,12 +152,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for skip_empty_string, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for skip_empty_string, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1000.txt', '1001.txt']
-        self.assertEqual(result, expected, "Problem with test for skip_empty_string, directory contents")
+        self.assertEqual(expected, result, "Problem with test for skip_empty_string, directory contents")
 
     def test_skip_form(self):
         """Test for when the file paths in the metadata are for form letters (not deleted)"""
@@ -175,12 +175,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for skip_form, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for skip_form, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(os.path.join(input_directory, 'documents'))
         expected = ['1.txt', '2.txt', '1.txt']
-        self.assertEqual(result, expected, "Problem with test for skip_form, directory contents")
+        self.assertEqual(expected, result, "Problem with test for skip_form, directory contents")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_find_academy_rows.py
+++ b/tests/cms_data_interchange_format/test_find_academy_rows.py
@@ -27,12 +27,12 @@ class MyTestCase(unittest.TestCase):
                     ['file_2.doc', 'academy appointment request', 'Academy Nominations', 'Academy_Application'],
                     ['file_3.doc', 'HELP WITH ACADEMY ISSUE', 'acad - academy nominations', 'Academy_Application'],
                     ['file_4.doc', 'Academy Issue', 'WEBACAD - Web Form Academy Nominations', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for both, df_academy")
+        self.assertEqual(expected, result, "Problem with test for both, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for both, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for both, df_academy_check")
 
     def test_code_desc(self):
         """Test for when the column code_description indicates academy applications are present"""
@@ -54,13 +54,13 @@ class MyTestCase(unittest.TestCase):
                     ['file_3.doc', 'x', 'WEBACAD - Web Form Academy Nominations', 'Academy_Application'],
                     ['file_4.doc', 'x', 'webacad - web form academy nominations', 'Academy_Application'],
                     ['file_5.doc', 'x', 'academy nomination', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for code_desc, df_academy")
+        self.assertEqual(expected, result, "Problem with test for code_desc, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_6.doc', 'x', 'academy awards', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for code_desc df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for code_desc df_academy_check")
 
     def test_corr_text(self):
         """Test for when the column correspondence_text indicates academy applications are present"""
@@ -81,14 +81,14 @@ class MyTestCase(unittest.TestCase):
                     ['file_3.doc', 'HELP WITH ACADEMY ISSUE', 'x', 'Academy_Application'],
                     ['file_5.doc', 'Academy Nominations', 'x', 'Academy_Application'],
                     ['file_6.doc', 'Military Academy - Application', 'x', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for COLUMN, df_academy")
+        self.assertEqual(expected, result, "Problem with test for COLUMN, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_1.doc', 'Sports Academy', 'x', 'Academy_Application'],
                     ['file_4.doc', 'academy vouchers', 'x', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for COLUMN, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for COLUMN, df_academy_check")
 
     def test_none(self):
         """Test for when no rows have academy applications"""
@@ -102,12 +102,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_academy")
+        self.assertEqual(expected, result, "Problem with test for none, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_academy_check")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_find_appraisal_rows.py
+++ b/tests/cms_data_interchange_format/test_find_appraisal_rows.py
@@ -33,17 +33,17 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in appraisal_df are correct.
         result = df_to_list(appraisal_df)
         expected = [['correspondence_document_name', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no appraisal), appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for none (no appraisal), appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no appraisal), appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for none (no appraisal), appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no appraisal), appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for none (no appraisal), appraisal_delete_log.csv")
 
     def test_one(self):
         """Test for when rows match only one appraisal category, if any"""
@@ -67,7 +67,7 @@ class MyTestCase(unittest.TestCase):
                     ['file_5.doc', 'x', 'Casework'],
                     ['file_6.doc', 'x', 'Job_Application'],
                     ['file_8.doc', 'academy nomination', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for one category, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for one category, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
                     ['file_4.doc', 'x', 'legal > case', 'Casework'],
                     ['file_7.doc', 'create jobs now', 'x', 'Job_Application'],
                     ['file_9.doc', 'good job with this one', 'x', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for one category, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for one category, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -85,7 +85,7 @@ class MyTestCase(unittest.TestCase):
                     ['file_5.doc', 'casework - forwarded to me for a response', 'x', 'Casework'],
                     ['file_6.doc', 'Internship applicant', 'x', 'Job_Application'],
                     ['file_8.doc', 'x', 'academy nomination', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for one category, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for one category, appraisal_delete_log.csv")
 
     def test_multiple(self):
         """Test for when rows match multiple appraisal categories, if any"""
@@ -104,14 +104,14 @@ class MyTestCase(unittest.TestCase):
                     ['file_1.doc', 'x', 'Casework|Job_Application'],
                     ['file_3.doc', 'x', 'Job_Application|Recommendation'],
                     ['file_4.doc', 'x', 'Casework|Job_Application|Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for multiple categories, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for multiple categories, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_5.doc', 'recommendation.doc', 'case > recommendation', 'Casework'],
                     ['file_5.doc', 'recommendation.doc', 'case > recommendation', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for multiple categories, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for multiple categories, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -120,7 +120,7 @@ class MyTestCase(unittest.TestCase):
                     ['file_3.doc', 'internship recommendation letter', 'x', 'Job_Application|Recommendation'],
                     ['file_4.doc', 'internship recommendation letter closed case file', 'x',
                      'Casework|Job_Application|Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for multiple categories, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for multiple categories, appraisal_delete_log.csv")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_find_casework_rows.py
+++ b/tests/cms_data_interchange_format/test_find_casework_rows.py
@@ -32,13 +32,13 @@ class MyTestCase(unittest.TestCase):
                     ['file_4.doc', 'CASEWORK', 'x', 'Casework'],
                     ['file_5.doc', 'Forwarded to me for a response', 'x', 'Casework'],
                     ['file_6.doc', 'Add to open case', 'x', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_casework")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_7.doc', 'Potential case', 'x', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_casework_check")
 
     def test_none(self):
         """Test for when no rows have casework"""
@@ -52,12 +52,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_casework")
+        self.assertEqual(expected, result, "Problem with test for none, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_casework_check")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_find_job_rows.py
+++ b/tests/cms_data_interchange_format/test_find_job_rows.py
@@ -27,14 +27,14 @@ class MyTestCase(unittest.TestCase):
                     ['file_1.doc', 'Intern Assignments', 'x', 'Job_Application'],
                     ['file_3.doc', 'batch intern response', 'x', 'Job_Application'],
                     ['file_4.doc', 'INTERNSHIP', 'x', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_job")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_2.doc', 'good job with everything', 'x', 'Job_Application'],
                     ['file_5.doc', 'Jobs Act', 'x', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_job_check")
 
     def test_none(self):
         """Test for when no rows have job applications"""
@@ -48,12 +48,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_job")
+        self.assertEqual(expected, result, "Problem with test for none, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_job_check")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_find_recommendation_rows.py
+++ b/tests/cms_data_interchange_format/test_find_recommendation_rows.py
@@ -30,13 +30,13 @@ class MyTestCase(unittest.TestCase):
                     ['file_3.doc', 'letters of recommendation for girl scouts', 'x', 'Recommendation'],
                     ['file_5.doc', 'RECOMMENDATION LETTER', 'x', 'Recommendation'],
                     ['file_6.doc', 'recommendation letters', 'x', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_recommendation")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_recommendation")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendation_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category'],
                     ['file_4.doc', 'Recommendation for policy', 'x', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for corr_text, df_recommendation_check")
+        self.assertEqual(expected, result, "Problem with test for corr_text, df_recommendation_check")
 
     def test_none(self):
         """Test for when no rows have recommendations"""
@@ -50,12 +50,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_recommendation are correct.
         result = df_to_list(df_recommendation)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_recommendation")
+        self.assertEqual(expected, result, "Problem with test for none, df_recommendation")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendation_check)
         expected = [['correspondence_document_name', 'correspondence_text', 'code_description', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_recommendation_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_recommendation_check")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_read_metadata.py
+++ b/tests/cms_data_interchange_format/test_read_metadata.py
@@ -34,7 +34,7 @@ class MyTestCase(unittest.TestCase):
                     ['City Three', 'GA', '30003', 'USA', 'EMAIL', 'Staffer_3', '20220330', '20220330', 'BLANK',
                      '20220330', 'EMAIL', '15003', 'PRO', '1', 'main', 'rights_pro.docx', 'BLANK', 'text3',
                      'COR', '15003', 'Rights > Workers', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for function read_metadata")
+        self.assertEqual(expected, result, "Problem with test for function read_metadata")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_read_metadata_file.py
+++ b/tests/cms_data_interchange_format/test_read_metadata_file.py
@@ -30,7 +30,7 @@ class MyTestCase(unittest.TestCase):
                      'City Two', 'GA', '30002', 'C2', 'Clarke', 'USA', 'D2', 'P2', 'Y', 'BLANK'],
                     ['1B', '3', '33', 'HO', 'Y', 'Y', 'BLANK', 'BLANK', '30 Elm Ave', 'BLANK', 'BLANK', 'BLANK',
                      'City Three', 'GA', '30003', 'C3', 'Clarke', 'USA', 'D3', 'P3', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for 1B")
+        self.assertEqual(expected, result, "Problem with test for 1B")
 
     def test_2a(self):
         """Test for the metadata file 2A.out"""
@@ -46,7 +46,7 @@ class MyTestCase(unittest.TestCase):
                      'EMAIL', '22', 'BLANK', 'BLANK', 'BLANK', 'BLANK'],
                     ['2A', '3', '3003', 'EMAIL', 'Staffer_3', '20220330', '20220330', 'BLANK', '20220330',
                      'EMAIL', '33', 'BLANK', 'BLANK', 'BLANK', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for 2A")
+        self.assertEqual(expected, result, "Problem with test for 2A")
 
     def test_2b(self):
         """Test for the metadata file 2B.out"""
@@ -57,7 +57,7 @@ class MyTestCase(unittest.TestCase):
                     ['2B', '1', '1001', '15001', 'CON'],
                     ['2B', '2', '2002', '15002', 'PRO'],
                     ['2B', '3', '3003', '15003', 'PRO']]
-        self.assertEqual(result, expected, "Problem with test for 2B")
+        self.assertEqual(expected, result, "Problem with test for 2B")
 
     def test_2c(self):
         """Test for the metadata file 2C.out"""
@@ -69,7 +69,7 @@ class MyTestCase(unittest.TestCase):
                     ['2C', '1', '1001', '1', 'main', 'taxes_con.docx', 'BLANK'],
                     ['2C', '2', '2002', '1', 'main', 'min_wage_pro.docx', 'BLANK'],
                     ['2C', '3', '3003', '1', 'main', 'rights_pro.docx', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for 2C")
+        self.assertEqual(expected, result, "Problem with test for 2C")
 
     def test_2d(self):
         """Test for the metadata file 2D.out"""
@@ -81,7 +81,7 @@ class MyTestCase(unittest.TestCase):
                     ['2D', '1', '1001', '1', 'CM', 'text1'],
                     ['2D', '2', '2002', '1', 'CM', 'text2'],
                     ['2D', '2', '3003', '1', 'CM', 'text3']]
-        self.assertEqual(result, expected, "Problem with test for 2D")
+        self.assertEqual(expected, result, "Problem with test for 2D")
 
     def test_8a(self):
         """Test for the metadata file 8A.out"""
@@ -92,7 +92,7 @@ class MyTestCase(unittest.TestCase):
                     ['8A', 'COR', '15001', 'Taxes', 'Y'],
                     ['8A', 'COR', '15002', 'Minimum Wage', 'BLANK'],
                     ['8A', 'COR', '15003', 'Rights > Workers', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for 8A")
+        self.assertEqual(expected, result, "Problem with test for 8A")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_remove_pii.py
+++ b/tests/cms_data_interchange_format/test_remove_pii.py
@@ -23,11 +23,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['constituent_id', 'city', 'state', 'zip_code', 'country']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 1B, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 1B, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '13', '14', '15', '18']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 1B, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 1B, values")
 
     def test_2a(self):
         """Test for columns in table 2A."""
@@ -41,11 +41,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the columns of the returned dataframe are correct.
         expected = ['constituent_id', 'correspondence_id', 'correspondence_type', 'staff', 'date_in', 'date_out',
                     'tickler_date', 'update_date', 'response_type']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 2A, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 2A, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '3', '4', '5', '6', '7', '8', '9', '10']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 2A, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 2A, values")
 
     def test_2b(self):
         """Test for columns in table 2B."""
@@ -57,11 +57,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['constituent_id', 'correspondence_id', 'correspondence_code', 'position']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 2B, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 2B, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '3', '4', '5']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 2B, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 2B, values")
 
     def test_2c(self):
         """Test for columns in table 2C."""
@@ -74,11 +74,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the columns of the returned dataframe are correct.
         expected = ['constituent_id', 'correspondence_id', '2C_sequence_number', 'document_type',
                     'correspondence_document_name', 'file_location']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 2C, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 2C, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '3', '4', '5', '6', '7']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 2C, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 2C, values")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_script.py
+++ b/tests/cms_data_interchange_format/test_script.py
@@ -265,20 +265,20 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
         result = csv_to_list(csv_path)
-        expected = [['Category', 'Count'],
-                    ['Metadata_Only', '2'],
-                    ['Directory_Only', '1'],
-                    ['Match', '4'],
-                    ['Metadata_Blank', '0']]
+        expected = [['Category', 'Row/File_Count', 'Row_Percent'],
+                    ['Match', '4', '67%'],
+                    ['Metadata_Only', '2', '33%'],
+                    ['Metadata_Blank', '0', '0%'],
+                    ['Directory_Only', '1', 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of the usability_report_matching_details.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching_details.csv')
         result = csv_to_list(csv_path, sort=True)
         expected = [['Category', 'Path'],
-                    ['Directory Only', f'{input_directory}\\documents\\out-custom\\1002.txt'],
-                    ['Metadata Only', f'{input_directory}\\documents\\in-email\\3.txt'],
-                    ['Metadata Only', f'{input_directory}\\documents\\out-custom\\100X.txt']]
+                    ['Directory Only', f'{input_directory.lower()}\\documents\\out-custom\\1002.txt'],
+                    ['Metadata Only', f'{input_directory.lower()}\\documents\\in-email\\3.txt'],
+                    ['Metadata Only', f'{input_directory.lower()}\\documents\\out-custom\\100x.txt']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")
 
         # Tests the contents of the usability_report_metadata.csv.

--- a/tests/cms_data_interchange_format/test_script.py
+++ b/tests/cms_data_interchange_format/test_script.py
@@ -73,7 +73,7 @@ class MyTestCase(unittest.TestCase):
         expected = ('\nThe script is running in access mode.\nIt will remove rows for deleted letters '
                     'and columns with PII, make copies of the metadata split by congress year, '
                     'and make a copy of the constituent letters organized by topic\n')
-        self.assertEqual(result, expected, "Problem with test for access, printed statement")
+        self.assertEqual(expected, result, "Problem with test for access, printed statement")
 
         # Tests the contents of the appraisal_check_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -86,7 +86,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'LETTER', 'Staffer_1', '20210110', '20210110', 'BLANK',
                      '20210110', 'LETTER', '11111', 'CON', '1', 'main', r'in-email\1.txt', 'BLANK', 'note text 1',
                      'COR', '11111', 'LEGAL CASE', 'Y', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal_check_log.csv")
 
         # Tests the contents of the appraisal_delete_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
                      '2C_sequence_number', 'document_type', 'correspondence_document_name', 'file_location',
                      'correspondence_text', 'code_type', 'code', 'code_description', 'inactive_flag',
                      'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal_delete_log.csv")
 
         # Tests the contents of archiving_correspondence_redacted.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_redacted.csv')
@@ -120,7 +120,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'EMAIL', 'Staffer_3', '20230330', '20230330', 'BLANK',
                      '20230330', 'EMAIL', '33333', 'PRO', '1', 'main', r'in-email\333.txt', 'BLANK',
                      'COR', '33333', 'RIGHTS', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
+        self.assertEqual(expected, result, "Problem with test for access, archiving_correspondence_redacted.csv")
 
         # Tests the contents of 2021-2022.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '2021-2022.csv')
@@ -138,7 +138,7 @@ class MyTestCase(unittest.TestCase):
                     ['City Three', 'GA', '30003', 'USA', 'EMAIL', 'Staffer_3', '20220330', '20220330', 'BLANK',
                      '20220330', 'EMAIL', '33333', 'PRO', '1', 'main', r'in-email\3.txt', 'BLANK',
                      'COR', '33333', 'RIGHTS', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for access, 2021-2022")
+        self.assertEqual(expected, result, "Problem with test for access, 2021-2022")
 
         # Tests the contents of 2023-2024.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '2023-2024.csv')
@@ -150,7 +150,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'EMAIL', 'Staffer_3', '20230330', '20230330', 'BLANK',
                      '20230330', 'EMAIL', '33333', 'PRO', '1', 'main', r'in-email\333.txt', 'BLANK',
                      'COR', '33333', 'RIGHTS', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for access, 2023-2024")
+        self.assertEqual(expected, result, "Problem with test for access, 2023-2024")
 
         # Tests the contents of undated.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', 'undated.csv')
@@ -162,7 +162,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'EMAIL', 'Staffer_3', 'BLANK', 'BLANK', 'BLANK',
                      'BLANK', 'EMAIL', '33333', 'PRO', '1', 'main', r'in-email\33.txt', 'BLANK',
                      'COR', '33333', 'RIGHTS', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for access, undated")
+        self.assertEqual(expected, result, "Problem with test for access, undated")
 
         # Tests that Correspondence_by_Topic has the expected files.
         by_topic = os.path.join(os.getcwd(), 'test_data', 'script', 'Correspondence_by_Topic')
@@ -172,7 +172,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(by_topic, 'RIGHTS', '3.txt'),
                     os.path.join(by_topic, 'RIGHTS', '33.txt'),
                     os.path.join(by_topic, 'RIGHTS', '333.txt')]
-        self.assertEqual(result, expected, "Problem with test for access, Correspondence_by_Topic")
+        self.assertEqual(expected, result, "Problem with test for access, Correspondence_by_Topic")
 
     def test_accession(self):
         """Test for when the script runs correctly in accession mode"""
@@ -186,7 +186,7 @@ class MyTestCase(unittest.TestCase):
         result = output.stdout
         expected = ('\nThe script is running in accession mode.\n'
                     'It will produce usability and appraisal reports and not change the export.\n')
-        self.assertEqual(result, expected, "Problem with test for accession, printed statement")
+        self.assertEqual(expected, result, "Problem with test for accession, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -205,7 +205,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'EMAIL', 'Staffer_3', '20230330', '20230330', 'BLANK',
                      '20230330', 'EMAIL', '33333', 'PRO', '1', 'main', 'out-custom\\100X.txt', 'BLANK',
                      'Recommendation for legislation', 'COR', '33333', 'RIGHTS', 'Y', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal_check_log.csv")
 
         # Tests the contents of the appraisal_delete_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -224,7 +224,7 @@ class MyTestCase(unittest.TestCase):
                     ['City Three', 'GA', '30003', 'USA', 'EMAIL', 'Staffer_3', '20220330', '2022-03-30', 'BLANK',
                      '20220330', 'EMAIL', '33333', 'PRO', '1', 'main', 'forms\\1.txt', 'BLANK', 'CASEWORK',
                      'COR', '33333', 'RIGHTS', 'Y', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal_delete_log.csv")
 
         # Tests the contents of the metadata_formatting_errors_date_out.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_date_out.csv')
@@ -239,7 +239,7 @@ class MyTestCase(unittest.TestCase):
                     ['City Three', 'GA', '30003', 'USA', 'EMAIL', 'Staffer_3', '20220330', '2022-03-30', 'BLANK',
                      '20220330', 'EMAIL', '33333', 'PRO', '1', 'main', 'forms\\1.txt', 'BLANK', 'COR', '33333',
                      'RIGHTS', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_date_out.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_date_out.csv")
 
         # Tests the contents of the metadata_formatting_errors_state.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_state.csv')
@@ -251,7 +251,7 @@ class MyTestCase(unittest.TestCase):
                     ['Caseyville', 'Georgia', '30002', 'USA', 'EMAIL', 'Staffer_2', '20220220', '2022 Feb', 'BLANK',
                      '20220220', 'EMAIL', '22222', 'PRO', '1', 'main', 'in-email\\2.txt', 'BLANK', 'COR', '22222',
                      'MINWAGE', 'Y']]
-        self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_state.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_state.csv")
 
         # Tests the contents of the topics_report.csv.
         csv_path = os.path.join('test_data', 'script', 'topics_report.csv')
@@ -260,7 +260,7 @@ class MyTestCase(unittest.TestCase):
                     ['RIGHTS', '3'],
                     ['LEGAL CASE', '2'],
                     ['MINWAGE', '1']]
-        self.assertEqual(result, expected, "Problem with test for accession, topics_report.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, topics_report.csv")
 
         # Tests the contents of the usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
@@ -270,7 +270,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '2', '33%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '1', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of the usability_report_matching_details.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching_details.csv')
@@ -279,7 +279,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', f'{input_directory.lower()}\\documents\\out-custom\\1002.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\in-email\\3.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\out-custom\\100x.txt']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching_details.csv")
 
         # Tests the contents of the usability_report_metadata.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_metadata.csv')
@@ -306,7 +306,7 @@ class MyTestCase(unittest.TestCase):
                     ['code', 'True', '0', '0.0', 'uncheckable'],
                     ['code_description', 'True', '0', '0.0', 'uncheckable'],
                     ['inactive_flag', 'True', '0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_metadata.csv")
 
     def test_appraisal(self):
         """Test for when the script runs correctly in appraisal mode."""
@@ -324,7 +324,7 @@ class MyTestCase(unittest.TestCase):
         result = output.stdout
         expected = ('\nThe script is running in appraisal mode.\n'
                     'It will delete letters due to appraisal but not change the metadata file.\n')
-        self.assertEqual(result, expected, "Problem with test for appraisal, printed statement")
+        self.assertEqual(expected, result, "Problem with test for appraisal, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -343,7 +343,7 @@ class MyTestCase(unittest.TestCase):
                     ['City One', 'GA', '30001', 'USA', 'EMAIL', 'Staffer_3', '20230330', '20230330', 'BLANK',
                      '20230330', 'EMAIL', '33333', 'PRO', '1', 'main', 'out-custom\\1002.txt', 'BLANK',
                      'Recommendation for legislation', 'COR', '33333', 'RIGHTS', 'Y', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal_check_log.csv")
 
         # Tests the contents of the appraisal_delete_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -362,7 +362,7 @@ class MyTestCase(unittest.TestCase):
                     ['City Three', 'GA', '30003', 'USA', 'EMAIL', 'Staffer_3', '20220330', '20220330', 'BLANK',
                      '20220330', 'EMAIL', '33333', 'PRO', '1', 'main', 'forms\\1.txt', 'BLANK', 'CASEWORK',
                      'COR', '33333', 'RIGHTS', 'Y', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal_delete_log.csv")
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
@@ -373,13 +373,13 @@ class MyTestCase(unittest.TestCase):
                      '0.1', today, today, 'BFC30C1C407A46A42D322B493E783D8A', 'Recommendation'],
                     [os.path.join('test_data', 'script', 'appraisal_copy', 'documents', 'in-email', '3.txt'),
                      '0.2', today, today, '3372E0A98AEBE7DB66A368010DB78AF3', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, file_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for appraisal, file_delete_log.csv")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['1B.out', '2A.out', '2B.out', '2C.out', '2D.out', '8A.out',
                     '1.txt', 'case_name.txt', '1001.txt', '1002.txt']
-        self.assertEqual(result, expected, "Problem with test for appraisal, input_directory contents")
+        self.assertEqual(expected, result, "Problem with test for appraisal, input_directory contents")
 
     def test_error_argument(self):
         """Test for when the script exits due to an argument error."""
@@ -393,7 +393,7 @@ class MyTestCase(unittest.TestCase):
         output = subprocess.run(f"python {script_path}", shell=True, stdout=subprocess.PIPE)
         result = output.stdout.decode('utf-8')
         expected = "Missing required arguments, input_directory and script_mode\r\n"
-        self.assertEqual(result, expected, "Problem with test for error argument, printed error")
+        self.assertEqual(expected, result, "Problem with test for error argument, printed error")
 
     # def test_accession(self):
     #     """Test for when the script runs correctly in accession mode."""
@@ -412,7 +412,7 @@ class MyTestCase(unittest.TestCase):
     #                  '20210110', 'LETTER', 'LEGAL CASE', 'CON', '1', 'main', 'legal_con.docx', 'BLANK'],
     #                 ['Caseyville', 'GA', '30002', 'USA', 'EMAIL', 'Staffer_2', '20220220', '20220220', 'BLANK',
     #                  '20220220', 'EMAIL', 'MINWAGE', 'PRO', '1', 'main', 'min_wage_pro.docx', 'BLANK']]
-    #     self.assertEqual(result, expected, "Problem with test for preservation, case_remains_log.csv")
+    #     self.assertEqual(expected, result, "Problem with test for preservation, case_remains_log.csv")
 
     def test_preservation(self):
         """Test for when the script runs correctly in preservation mode."""
@@ -426,7 +426,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the print statement.
         result = output.stdout
         expected = '\nThe script is running in preservation mode.\nThe steps are TBD.\n'
-        self.assertEqual(result, expected, "Problem with test for preservation, printed statement")
+        self.assertEqual(expected, result, "Problem with test for preservation, printed statement")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_sort_correspondence.py
+++ b/tests/cms_data_interchange_format/test_sort_correspondence.py
@@ -63,7 +63,7 @@ class MyTestCase(unittest.TestCase):
         # Verifies the expected topic folders were created and have the expected files in them.
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for blank")
+        self.assertEqual(expected, result, "Problem with test for blank")
 
     def test_duplicate_file(self):
         """Test for when a file is in the metadata with the same topic more than once"""
@@ -78,7 +78,7 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'dogs', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_file")
+        self.assertEqual(expected, result, "Problem with test for duplicate_file")
 
     def test_duplicate_topic(self):
         """Test for when a topic is in the metadata more than once"""
@@ -95,7 +95,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'cats', 'file3.txt'),
                     os.path.join(self.by_topic, 'cats', 'file4.txt'),
                     os.path.join(self.by_topic, 'dogs', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_topic")
+        self.assertEqual(expected, result, "Problem with test for duplicate_topic")
 
     def test_filenotfounderror(self):
         """Test for when a file is in the metadata but not the directory"""
@@ -110,13 +110,13 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, topic folders")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
         expected = [['dogs', r'new\in-email\file2.txt'],
                     ['park', r'\doc\in-email\file4.txt']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, log")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, log")
 
     def test_folder_empty(self):
         """Test for when no files for a topic are in the directory and the topic folder is empty"""
@@ -131,19 +131,19 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'farm', 'file3.txt'),
                     os.path.join(self.by_topic, 'park', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder empty, topic folders")
+        self.assertEqual(expected, result, "Problem with test for folder empty, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
         expected = [['cats', r'in-email\file01.txt'],
                     ['dogs', r'in-email\new\file2.txt']]
-        self.assertEqual(result, expected, "Problem with test for folder empty, log")
+        self.assertEqual(expected, result, "Problem with test for folder empty, log")
 
         # Verifies folders without a file are not still present.
         result = [os.path.exists(os.path.join(self.by_topic, 'cats')),
                   os.path.exists(os.path.join(self.by_topic, 'dogs'))]
         expected = [False, False]
-        self.assertEqual(result, expected, "Problem with test for folder empty, folders not deleted")
+        self.assertEqual(expected, result, "Problem with test for folder empty, folders not deleted")
 
     def test_folder_name_error(self):
         """Test for when a topic contains a character that cannot be in a folder name"""
@@ -160,7 +160,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'Ga_', 'file2.txt'),
                     os.path.join(self.by_topic, '_H_', 'file3.txt'),
                     os.path.join(self.by_topic, '_pa_rk_', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name error")
+        self.assertEqual(expected, result, "Problem with test for folder name error")
 
     def test_folder_name_trailing(self):
         """Test for when a topic ends with a space or period, which cannot be in the folder name"""
@@ -177,7 +177,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'cat', 'file2.txt'),
                     os.path.join(self.by_topic, 'dog', 'file3.txt'),
                     os.path.join(self.by_topic, 'park and rec', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name trailing")
+        self.assertEqual(expected, result, "Problem with test for folder name trailing")
 
     def test_outgoing(self):
         """Test for when some rows are for outgoing correspondence and should be skipped"""
@@ -192,7 +192,7 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for outgoing")
+        self.assertEqual(expected, result, "Problem with test for outgoing")
 
     def test_unique(self):
         """Test for when topic and file is unique"""
@@ -209,7 +209,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'dogs', 'file2.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt'),
                     os.path.join(self.by_topic, 'park', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_topics_report.py
+++ b/tests/cms_data_interchange_format/test_topics_report.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
                     ['BLANK', '1'],
                     ['Pet Parade', '1'],
                     ['education', '1']]
-        self.assertEqual(result, expected, "Problem with test for all")
+        self.assertEqual(expected, result, "Problem with test for all")
 
     def test_blanks(self):
         """Test for when group is blank"""
@@ -47,7 +47,7 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'Topic_Count'],
                     ['BLANK', '6']]
-        self.assertEqual(result, expected, "Problem with test for blanks")
+        self.assertEqual(expected, result, "Problem with test for blanks")
 
     def test_repeat(self):
         """Test for when groups are repeated"""
@@ -64,7 +64,7 @@ class MyTestCase(unittest.TestCase):
                     ['Farms', '4'],
                     ['Pets', '3'],
                     ['Econ', '2']]
-        self.assertEqual(result, expected, "Problem with test for repeat")
+        self.assertEqual(expected, result, "Problem with test for repeat")
 
     def test_unique(self):
         """Test for when each group is used once"""
@@ -79,7 +79,7 @@ class MyTestCase(unittest.TestCase):
                     ['Econ', '1'],
                     ['farm > aid', '1'],
                     ['pets', '1']]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/cms_data_interchange_format/test_update_path.py
+++ b/tests/cms_data_interchange_format/test_update_path.py
@@ -11,67 +11,67 @@ class MyTestCase(unittest.TestCase):
         """Test for a new pattern"""
         file_path = update_path(r'new\folder\file.txt', 'input_dir')
         expected = 'error_new'
-        self.assertEqual(file_path, expected, "Problem with test for error")
+        self.assertEqual(expected, file_path, "Problem with test for error")
 
     def test_error_partial(self):
         """Test for a new pattern that is a partial match to an existing pattern (still an error)"""
         file_path = update_path(r'enews\folder\file.txt', 'input_dir')
         expected = 'error_new'
-        self.assertEqual(file_path, expected, "Problem with test for error partial")
+        self.assertEqual(expected, file_path, "Problem with test for error partial")
 
     def test_match_attachments(self):
         """Test for the pattern attachments\\..\\file.ext"""
         file_path = update_path(r'attachments\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\attachments\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match attachments")
+        self.assertEqual(expected, file_path, "Problem with test for match attachments")
 
     def test_match_case_custom(self):
         """Test for the pattern case-custom\\..\\file.ext"""
         file_path = update_path(r'case-custom\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\case-custom\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match case-custom")
+        self.assertEqual(expected, file_path, "Problem with test for match case-custom")
 
     def test_match_case_files(self):
         """Test for the pattern case-files\\..\\file.ext"""
         file_path = update_path(r'case-files\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\case-files\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match case-files")
+        self.assertEqual(expected, file_path, "Problem with test for match case-files")
 
     def test_match_documents(self):
         """Test for the pattern documents\\..\\file.ext"""
         file_path = update_path(r'documents\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\documents\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match documents")
+        self.assertEqual(expected, file_path, "Problem with test for match documents")
 
     def test_match_enewsletters(self):
         """Test for the pattern enewsletters\\..\\file.ext"""
         file_path = update_path(r'enewsletters\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\enewsletters\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match enewsletters")
+        self.assertEqual(expected, file_path, "Problem with test for match enewsletters")
 
     def test_match_form_attachments(self):
         """Test for the pattern form-attachments\\..\\file.ext"""
         file_path = update_path(r'form-attachments\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\form-attachments\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match form-attachments")
+        self.assertEqual(expected, file_path, "Problem with test for match form-attachments")
 
     def test_match_forms(self):
         """Test for the pattern forms\\..\\file.ext"""
         file_path = update_path(r'forms\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\forms\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match forms")
+        self.assertEqual(expected, file_path, "Problem with test for match forms")
 
     def test_match_in_email(self):
         """Test for the pattern in-email\\..\\file.ext"""
         file_path = update_path(r'in-email\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\in-email\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match in-email")
+        self.assertEqual(expected, file_path, "Problem with test for match in-email")
 
     def test_match_out_custom(self):
         """Test for the pattern out-custom\\..\\file.ext"""
         file_path = update_path(r'out-custom\folder\file.txt', 'input_dir')
         expected = r'input_dir\documents\out-custom\folder\file.txt'
-        self.assertEqual(file_path, expected, "Problem with test for match out-custom")
+        self.assertEqual(expected, file_path, "Problem with test for match out-custom")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_appraisal_check_df.py
+++ b/tests/css_archiving_format/test_appraisal_check_df.py
@@ -27,7 +27,7 @@ class MyTestCase(unittest.TestCase):
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30601', '', 'CASE', r'doc\Case_File.txt', '', '', '', r'form\a.txt', '', 'Casework'],
                     ['30603', '', '', '', '', 'started case Tue', r'case\abc.txt', '', 'Mr._Case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one column")
+        self.assertEqual(expected, result, "Problem with test for one column")
 
     def test_one_column(self):
         """Test for when the keyword is in one column per row"""
@@ -52,7 +52,7 @@ class MyTestCase(unittest.TestCase):
                     ['30603', '', '', '', '', '', 'started case Tue', '', 'a_b', 'Casework'],
                     ['30604', '', 'note', r'doc\file2.txt', '', '', 'reply note', r'case\abc.txt', '', 'Casework'],
                     ['30606', '', '', '', r'doc\file4.txt', '', 'Note', r'letter\123.txt', 'Mr._Case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one column")
+        self.assertEqual(expected, result, "Problem with test for one column")
 
     def test_no_column(self):
         """Test for when the keyword is in no columns"""
@@ -68,7 +68,7 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for no column")
+        self.assertEqual(expected, result, "Problem with test for no column")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_check_arguments.py
+++ b/tests/css_archiving_format/test_check_arguments.py
@@ -17,11 +17,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
         
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - access, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - access, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_correspondence.dat'), metadata_path,
                          "Problem with correct - access, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with correct - access, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
+        self.assertEqual('access', script_mode, "Problem with correct - access, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - access, errors_list")
 
     def test_correct_accession(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is accession."""
@@ -31,11 +31,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - accession, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - accession, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'), metadata_path,
                          "Problem with correct - accession, metadata_path")
-        self.assertEqual(script_mode, 'accession', "Problem with correct - accession, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - accession, errors_list")
+        self.assertEqual('accession', script_mode, "Problem with correct - accession, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - accession, errors_list")
 
     def test_correct_appraisal(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is appraisal."""
@@ -45,11 +45,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - appraisal, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - appraisal, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_correspondence.dat'), metadata_path,
                          "Problem with correct - appraisal, metadata_path")
-        self.assertEqual(script_mode, 'appraisal', "Problem with correct - appraisal, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
+        self.assertEqual('appraisal', script_mode, "Problem with correct - appraisal, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - access, errors_list")
 
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists, and mode is preservation."""
@@ -59,11 +59,11 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_path, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with correct - preservation, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with correct - preservation, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_CORRESPONDENCE.dat'), metadata_path,
                          "Problem with correct - preservation, metadata_path")
-        self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
+        self.assertEqual('preservation', script_mode, "Problem with correct - preservation, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - preservation, errors_list")
 
     def test_error_missing_one(self):
         """Test for when one required argument (mode) is missing."""
@@ -74,11 +74,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = ["Missing one of the required arguments, input_directory or script_mode"]
-        self.assertEqual(input_directory, input_dir, "Problem with error - missing one, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with error - missing one, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_correspondence.dat'), metadata_path,
                          "Problem with error - missing one, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with error - missing one, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - missing one, errors_list")
+        self.assertEqual(None, script_mode, "Problem with error - missing one, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - missing one, errors_list")
 
     def test_error_missing_two(self):
         """Test for when both required arguments are missing."""
@@ -88,10 +88,10 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = ["Missing required arguments, input_directory and script_mode"]
-        self.assertEqual(input_directory, None, "Problem with error - missing two, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with error - missing two, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with error - missing two, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - missing two, errors_list")
+        self.assertEqual(None, input_directory, "Problem with error - missing two, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with error - missing two, metadata_path")
+        self.assertEqual(None, script_mode, "Problem with error - missing two, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - missing two, errors_list")
 
     def test_error_mode(self):
         """Test for when the mode argument is not an expected value."""
@@ -102,11 +102,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = ["Provided mode 'unexpected' is not one of the expected modes"]
-        self.assertEqual(input_directory, input_dir, "Problem with error - mode, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with error - mode, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_correspondence.dat'), metadata_path,
                          "Problem with error - mode, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with error - mode, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - mode, errors_list")
+        self.assertEqual(None, script_mode, "Problem with error - mode, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - mode, errors_list")
 
     def test_error_path_dat(self):
         """Test for when input_directory contains no archiving correspondence dat file."""
@@ -117,10 +117,10 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = ["No archiving_correspondence.dat file in the input_directory"]
-        self.assertEqual(input_directory, input_dir, "Problem with error - path dat, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with error - path dat, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - path dat, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - path dat, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with error - path dat, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with error - path dat, metadata_path")
+        self.assertEqual('access', script_mode, "Problem with error - path dat, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - path dat, errors_list")
 
     def test_error_path_invalid(self):
         """Test for when input_directory is a path that does not exist."""
@@ -131,10 +131,10 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = [f"Provided input_directory '{input_dir}' does not exist"]
-        self.assertEqual(input_directory, None, "Problem with error - path invalid, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with error - path invalid, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - path invalid, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - path invalid, errors_list")
+        self.assertEqual(None, input_directory, "Problem with error - path invalid, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with error - path invalid, metadata_path")
+        self.assertEqual('access', script_mode, "Problem with error - path invalid, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - path invalid, errors_list")
 
     def test_error_too_many_arg(self):
         """Test for when more than the required two arguments are provided."""
@@ -145,11 +145,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_errors = ["Provided more than the required arguments, input_directory and script_mode"]
-        self.assertEqual(input_directory, input_dir, "Problem with error - too many arg, input_directory")
-        self.assertEqual(metadata_path, os.path.join(input_dir, 'archiving_correspondence.dat'),
+        self.assertEqual(input_dir, input_directory, "Problem with error - too many arg, input_directory")
+        self.assertEqual(os.path.join(input_dir, 'archiving_correspondence.dat'), metadata_path,
                          "Problem with error - too many arg, metadata_path")
-        self.assertEqual(script_mode, 'access', "Problem with error - too many arg, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with error - too many arg, errors_list")
+        self.assertEqual('access', script_mode, "Problem with error - too many arg, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with error - too many arg, errors_list")
 
     def test_errors(self):
         """Test for multiple errors."""
@@ -162,10 +162,10 @@ class MyTestCase(unittest.TestCase):
         expected_errors = [f"Provided input_directory '{input_dir}' does not exist",
                            "Provided mode 'error' is not one of the expected modes",
                            "Provided more than the required arguments, input_directory and script_mode"]
-        self.assertEqual(input_directory, None, "Problem with errors, input_directory")
-        self.assertEqual(metadata_path, None, "Problem with errors, metadata_path")
-        self.assertEqual(script_mode, None, "Problem with errors, script_mode")
-        self.assertEqual(errors_list, expected_errors, "Problem with errors, errors_list")
+        self.assertEqual(None, input_directory, "Problem with errors, input_directory")
+        self.assertEqual(None, metadata_path, "Problem with errors, metadata_path")
+        self.assertEqual(None, script_mode, "Problem with errors, script_mode")
+        self.assertEqual(expected_errors, errors_list, "Problem with errors, errors_list")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_check_letter_matching.py
+++ b/tests/css_archiving_format/test_check_letter_matching.py
@@ -46,7 +46,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 2, '25%'],
                     ['Metadata_Blank', 4, '50%'],
                     ['Directory_Only', 4, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for all, summary")
+        self.assertEqual(expected, result, "Problem with test for all, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
@@ -57,7 +57,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', f'{input_directory.lower()}\\documents\\indivletters\\500.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\formletters\\form_b.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\indivletters\\300.txt']]
-        self.assertEqual(result, expected, "Problem with test for all, details")
+        self.assertEqual(expected, result, "Problem with test for all, details")
 
     def test_blanks(self):
         """Test for when the document columns include blanks"""
@@ -80,12 +80,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 0, '0%'],
                     ['Metadata_Blank', 8, '80%'],
                     ['Directory_Only', 0, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for blanks, summary")
+        self.assertEqual(expected, result, "Problem with test for blanks, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for blanks, details")
+        self.assertEqual(expected, result, "Problem with test for blanks, details")
 
     def test_directory_only(self):
         """Test for when some letters are in the directory but not the metadata"""
@@ -104,7 +104,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 0, '0%'],
                     ['Metadata_Blank', 0, '0%'],
                     ['Directory_Only', 6, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, summary")
+        self.assertEqual(expected, result, "Problem with test for directory_only, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
@@ -115,7 +115,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', f'{input_directory.lower()}\\documents\\indivletters\\300.txt'],
                     ['Directory Only', f'{input_directory.lower()}\\documents\\indivletters\\400.txt'],
                     ['Directory Only', f'{input_directory.lower()}\\documents\\indivletters\\500.txt']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, details")
+        self.assertEqual(expected, result, "Problem with test for directory_only, details")
 
     def test_match(self):
         """Test for when the metadata and input directory match (some repeat, some capitalization differences)"""
@@ -142,12 +142,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 0, '0%'],
                     ['Metadata_Blank', 0, '0%'],
                     ['Directory_Only', 0, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for match, summary")
+        self.assertEqual(expected, result, "Problem with test for match, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for match, details")
+        self.assertEqual(expected, result, "Problem with test for match, details")
 
     def test_metadata_only(self):
         """Test for when some letters are in the metadata but not the directory"""
@@ -174,7 +174,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 7, '88%'],
                     ['Metadata_Blank', 0, '0%'],
                     ['Directory_Only', 0, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, summary")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'), sort=True)
@@ -186,7 +186,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\indivletters\\300.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\indivletters\\400.txt'],
                     ['Metadata Only', f'{input_directory.lower()}\\documents\\indivletters\\500.txt']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, details")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, details")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_check_metadata_formatting.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting.py
@@ -32,13 +32,13 @@ class MyTestCase(unittest.TestCase):
         in_date_mismatch = check_metadata_formatting('in_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(in_date_mismatch, 5, "Problem with test for in_date, count")
+        self.assertEqual(5, in_date_mismatch, "Problem with test for in_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_in_date.csv'))
         expected = [['zip', 'in_date'], [30602, '20001212.0600'], [30604, '2000'], [30605, '2000-12-12'],
                     [30606, 'Dec 12, 2000'], [30606, 'rcvd 20001212']]
-        self.assertEqual(result, expected, "Problem with test for in_date, report")
+        self.assertEqual(expected, result, "Problem with test for in_date, report")
 
     def test_out_date(self):
         """Test for the out_date column, including correct cells, formatting errors, and blanks"""
@@ -49,13 +49,13 @@ class MyTestCase(unittest.TestCase):
         out_date_mismatch = check_metadata_formatting('out_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_date_mismatch, 5, "Problem with test for out_date, count")
+        self.assertEqual(5, out_date_mismatch, "Problem with test for out_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_out_date.csv'))
         expected = [['zip', 'out_date'], [30602, '20001212.0600'], [30604, '2000'], [30605, '2000-12-12'],
                     [30606, 'Dec 12, 2000'], [30606, 'rcvd 20001212']]
-        self.assertEqual(result, expected, "Problem with test for out_date, report")
+        self.assertEqual(expected, result, "Problem with test for out_date, report")
 
     def test_state(self):
         """Test for the state column, including correct cells, formatting errors, and blanks"""
@@ -66,12 +66,12 @@ class MyTestCase(unittest.TestCase):
         state_mismatch = check_metadata_formatting('state', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 3, "Problem with test for state, count")
+        self.assertEqual(3, state_mismatch, "Problem with test for state, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_state.csv'))
         expected = [['state', 'zip'], ['ga', 30603], ['GEORGIA', 30604], ['NDK', 30606]]
-        self.assertEqual(result, expected, "Problem with test for state, report")
+        self.assertEqual(expected, result, "Problem with test for state, report")
 
     def test_zip(self):
         """Test for the zip column, including correct cells, formatting errors, and blanks"""
@@ -82,12 +82,12 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 4, "Problem with test for zip, count")
+        self.assertEqual(4, zip_mismatch, "Problem with test for zip, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_zip.csv'))
         expected = [['state', 'zip'], ['MS', '306024444'], ['TX', 'no zip'], ['DC', 'no zip'], ['MO', '3060']]
-        self.assertEqual(result, expected, "Problem with test for zip, report")
+        self.assertEqual(expected, result, "Problem with test for zip, report")
 
     def test_column_blank(self):
         """Test for a column that is entirely blank, which would be the same for any column"""
@@ -97,12 +97,12 @@ class MyTestCase(unittest.TestCase):
         state_mismatch = check_metadata_formatting('state', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 'column_blank', "Problem with test for column_blank, count")
+        self.assertEqual('column_blank', state_mismatch, "Problem with test for column_blank, count")
 
         # Tests the report was not made.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_state.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for no column_blank, report")
+        self.assertEqual(expected, result, "Problem with test for no column_blank, report")
 
     def test_column_missing(self):
         """Test for a column that is missing, which would be the same for any column"""
@@ -112,12 +112,12 @@ class MyTestCase(unittest.TestCase):
         out_date_mismatch = check_metadata_formatting('out_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_date_mismatch, 'column_missing', "Problem with test for column_missing, count")
+        self.assertEqual('column_missing', out_date_mismatch, "Problem with test for column_missing, count")
 
         # Tests the report was not made.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_date.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for column_missing, report")
+        self.assertEqual(expected, result, "Problem with test for column_missing, report")
 
     def test_no_errors(self):
         """Test for the column has no formatting errors, which would be the same for any column"""
@@ -127,12 +127,12 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 0, "Problem with test for no errors, count")
+        self.assertEqual(0, zip_mismatch, "Problem with test for no errors, count")
 
         # Tests the report was not made.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for no errors, report")
+        self.assertEqual(expected, result, "Problem with test for no errors, report")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_check_metadata_formatting_multi.py
+++ b/tests/css_archiving_format/test_check_metadata_formatting_multi.py
@@ -37,7 +37,7 @@ class MyTestCase(unittest.TestCase):
         in_document_name_mismatch = check_metadata_formatting_multi('in_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(in_document_name_mismatch, 3, "Problem with test for blob, count")
+        self.assertEqual(3, in_document_name_mismatch, "Problem with test for blob, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_in_document_name.csv'))
@@ -45,7 +45,7 @@ class MyTestCase(unittest.TestCase):
                     [30602, 'root\\documents\\BlobExport\\foldera\\filea.txt'],
                     [30606, 'dir\\..\\documents\\BlobExport\\folder1\\file1.txt'],
                     [30607, 'fileb.txt']]
-        self.assertEqual(result, expected, "Problem with test for blob, report")
+        self.assertEqual(expected, result, "Problem with test for blob, report")
 
     def test_dos(self):
         """Test for the dos pattern, including correct cells, formatting errors, and blanks"""
@@ -61,14 +61,14 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 2, "Problem with test for dos, count")
+        self.assertEqual(2, out_document_name_mismatch, "Problem with test for dos, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
         expected = [['zip', 'out_document_name'],
                     [30602, 'root\\\\smith-atlanta\\dos\\public\\foldera\\filea.txt'],
                     [30606, 'dir\\\\smith-atlanta\\dos\\public\\folder1\\file1.txt']]
-        self.assertEqual(result, expected, "Problem with test for dos, report")
+        self.assertEqual(expected, result, "Problem with test for dos, report")
 
     def test_e(self):
         """Test for the e\\: pattern, including correct cells, formatting errors, and blanks"""
@@ -81,13 +81,13 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 1, "Problem with test for e, count")
+        self.assertEqual(1, out_document_name_mismatch, "Problem with test for e, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
         expected = [['zip', 'out_document_name'],
                     [30602, 'root\\e:\\emailobj\\200202\\416120451.txt']]
-        self.assertEqual(result, expected, "Problem with test for e, report")
+        self.assertEqual(expected, result, "Problem with test for e, report")
 
     def test_column_blank(self):
         """Test for when the column is blank"""
@@ -101,12 +101,12 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 'column_blank', "Problem with test for 'column_blank', count")
+        self.assertEqual('column_blank', out_document_name_mismatch, "Problem with test for 'column_blank', count")
 
         # Tests the report was not made
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for 'column_blank', report")
+        self.assertEqual(expected, result, "Problem with test for 'column_blank', report")
 
     def test_column_missing(self):
         """Test for when the column is missing"""
@@ -120,12 +120,12 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 'column_missing', "Problem with test for column_missing, count")
+        self.assertEqual('column_missing', out_document_name_mismatch, "Problem with test for column_missing, count")
 
         # Tests the report was not made
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for column_missing, report")
+        self.assertEqual(expected, result, "Problem with test for column_missing, report")
 
     def test_no_errors(self):
         """Test for both patterns when there are no errors or blanks"""
@@ -139,12 +139,12 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 0, "Problem with test for no errors, count")
+        self.assertEqual(0, out_document_name_mismatch, "Problem with test for no errors, count")
 
         # Tests the report was not made
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
         expected = False
-        self.assertEqual(result, expected, "Problem with test for no errors, report")
+        self.assertEqual(expected, result, "Problem with test for no errors, report")
 
     def test_only_errors(self):
         """Test for when there are only errors, no correct or blanks"""
@@ -157,7 +157,7 @@ class MyTestCase(unittest.TestCase):
         out_document_name_mismatch = check_metadata_formatting_multi('out_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(out_document_name_mismatch, 4, "Problem with test for only errors, count")
+        self.assertEqual(4, out_document_name_mismatch, "Problem with test for only errors, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_out_document_name.csv'))
@@ -166,7 +166,7 @@ class MyTestCase(unittest.TestCase):
                     [30602, '..\\documents\\file2.txt'],
                     [30603, '\\public\\file1.txt'],
                     [30604, 'file2.txt']]
-        self.assertEqual(result, expected, "Problem with test for only, report")
+        self.assertEqual(expected, result, "Problem with test for only, report")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_check_metadata_usability.py
+++ b/tests/css_archiving_format/test_check_metadata_usability.py
@@ -78,7 +78,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', True, 0, 0.0, 'uncheckable'],
                     ['out_document_name', True, 0, 0, '0'],
                     ['out_fillin', True, 0, 0.0, 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for correct")
+        self.assertEqual(expected, result, "Problem with test for correct")
 
     def test_columns_blanks(self):
         """Test for when some columns have blank cells"""
@@ -133,7 +133,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', True, 3, 75.0, 'uncheckable'],
                     ['out_document_name', True, 3, 75.0, '0'],
                     ['out_fillin', True, 4, 100.0, 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for blanks")
+        self.assertEqual(expected, result, "Problem with test for blanks")
 
     def test_columns_extra(self):
         """Test for when some columns are not expected"""
@@ -181,7 +181,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_document_name', 'True', 0, 0.0, '0'],
                     ['out_fillin', 'True', 0, 0.0, 'uncheckable'],
                     ['extra', 'Error: unexpected column', 0, 0.0, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for extra")
+        self.assertEqual(expected, result, "Problem with test for extra")
 
     def test_columns_format(self):
         """Test for when some cells in the six tested columns do not match the expected formats"""
@@ -238,7 +238,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', True, 0, 0.0, 'uncheckable'],
                     ['out_document_name', True, 1, 20.0, '1'],
                     ['out_fillin', True, 0, 0.0, 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for formatting")
+        self.assertEqual(expected, result, "Problem with test for formatting")
 
     def test_columns_missing(self):
         """Test for when some columns are missing"""
@@ -286,7 +286,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', False, 'BLANK', 'BLANK', 'uncheckable'],
                     ['out_document_name', True, 0.0, 0.0, '0'],
                     ['out_fillin', False, 'BLANK', 'BLANK', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for missing")
+        self.assertEqual(expected, result, "Problem with test for missing")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_delete_appraisal_letters.py
+++ b/tests/css_archiving_format/test_delete_appraisal_letters.py
@@ -59,12 +59,12 @@ class MyTestCase(unittest.TestCase):
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\objects\222222.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'],]
-        self.assertEqual(result, expected, "Problem with test for in_document_name, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for in_document_name, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['form_a.txt', '333333.txt']
-        self.assertEqual(result, expected, "Problem with test for in_document_name, directory contents")
+        self.assertEqual(expected, result, "Problem with test for in_document_name, directory contents")
 
     def test_in_skip(self):
         """Test for deleting files in the in_document_name column, where some rows should be skipped"""
@@ -91,12 +91,12 @@ class MyTestCase(unittest.TestCase):
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\objects\222222.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Academy_Application'], ]
-        self.assertEqual(result, expected, "Problem with test for in_skip, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for in_skip, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['form_a.txt', '333333.txt']
-        self.assertEqual(result, expected, "Problem with test for in_skip, directory contents")
+        self.assertEqual(expected, result, "Problem with test for in_skip, directory contents")
 
     def test_out_document_name(self):
         """Test for deleting files in the out_document_name column"""
@@ -121,12 +121,12 @@ class MyTestCase(unittest.TestCase):
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\letter\333333.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
-        self.assertEqual(result, expected, "Problem with test for out_document_name, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['form_a.txt', 'test.txt', '222222.txt']
-        self.assertEqual(result, expected, "Problem with test for out_document_name, directory contents")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, directory contents")
 
     def test_out_skip(self):
         """Test for deleting files in the out_document_name column, where some rows should be skipped"""
@@ -155,12 +155,12 @@ class MyTestCase(unittest.TestCase):
                      0.2, today, today, '45F12DDF78B657FA2DC1B0A2A0FB3ADD', 'Academy_Application'],
                     [r'..\documents\letter\333333.txt'.replace('..', input_directory),
                      0.7, today, today, '2CAA9E5BD685EFE4C9FCC9473375A86B', 'Casework'], ]
-        self.assertEqual(result, expected, "Problem with test for out_skip, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for out_skip, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['form_a.txt', 'test.txt', '222222.txt']
-        self.assertEqual(result, expected, "Problem with test for out_skip, directory contents")
+        self.assertEqual(expected, result, "Problem with test for out_skip, directory contents")
 
     def test_error_new(self):
         """Test for when paths in the metadata do not match expected patterns"""
@@ -182,7 +182,7 @@ class MyTestCase(unittest.TestCase):
                      'Cannot determine file path: new path pattern in metadata'],
                     [r'indivletters\500.txt', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'Cannot determine file path: new path pattern in metadata']]
-        self.assertEqual(result, expected, "Problem with test for error_new, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for error_new, file deletion log")
 
     def test_filenotfounderror_in(self):
         """Test for when files in in_document_name are not present and cannot be deleted"""
@@ -204,7 +204,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\indivletters\500.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror - in, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror - in, file deletion log")
 
     def test_filenotfounderror_out(self):
         """Test for when files in out_document_name are not present and cannot be deleted"""
@@ -226,7 +226,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\indivletters\500.txt'.replace('..', input_directory),
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror - out, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror - out, file deletion log")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_file_deletion_log.py
+++ b/tests/css_archiving_format/test_file_deletion_log.py
@@ -39,7 +39,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [file_path_1, 0.0, '2025-04-07', today, '89D31DC38A6C7D68653F452A2F44AC3D', 'Academy_Application'],
                     [file_path_2, 1.2, '2025-04-07', today, '9452DF84756C849AE0ED9FE2A14948F5', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for delete two")
+        self.assertEqual(expected, result, "Problem with test for delete two")
 
     def test_error_new(self):
         """Test for adding a row for a file with a new path format in the metadata."""
@@ -58,7 +58,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [file_path, 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'Cannot determine file path: new path pattern in metadata']]
-        self.assertEqual(result, expected, "Problem with test for error_new")
+        self.assertEqual(expected, result, "Problem with test for error_new")
 
     def test_filenotfounderror(self):
         """Test for adding a row for a file that cannot be deleted."""
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes'],
                     [file_path, 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror")
 
     def test_header(self):
         """Test for making a new log with a header row."""
@@ -87,7 +87,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the file deletion log.
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for header")
+        self.assertEqual(expected, result, "Problem with test for header")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_find_academy_rows.py
+++ b/tests/css_archiving_format/test_find_academy_rows.py
@@ -43,7 +43,7 @@ class MyTestCase(unittest.TestCase):
                      'Academy_Application'],
                     ['30603', '', 'academy nomination', '', '', '', 'For academy nomination support', '', '',
                      'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_academy")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
@@ -51,7 +51,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30605', 'Admin', 'academy', '', '', 'Admin', '', '', '', 'Academy_Application'],
                     ['30606', 'Admin', '', '', '', 'Admin', '', r'doc\academy_voucher.txt', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_academy_check")
 
     def test_in_text(self):
         """Test for when column in_text contains academy nomination"""
@@ -71,14 +71,14 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Military', 'For Academy Nomination Letter', '', '', 'Military', '', '', '',
                      'Academy_Application'],
                     ['30602', 'Admin', 'academy nomination', '', '', '', 'note', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_academy")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30603', 'Arts', 'Arts academy', '', '', 'Arts', '', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_academy_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains one of the topics indicating academy applications"""
@@ -99,14 +99,14 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'military service academy', '', '', '', 'Admin', '', '', '', 'Academy_Application'],
                     ['30602', 'Military^Academy Applicant', '', '', '', '', '', '', '', 'Academy_Application'],
                     ['30604', 'MILITARY SERVICE ACADEMY^ADMIN', '', '', '', '', '', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_academy")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Science Academy', '', '', '', 'Water', '', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_academy_check")
 
     def test_none(self):
         """Test for when no patterns indicating academy applications are present"""
@@ -121,13 +121,13 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_academy)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_academy")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text', 
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_academy_check")
 
     def test_out_text(self):
         """Test for when column out_text contains academy nomination"""
@@ -148,7 +148,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', '', '', '', '', '', 'for academy nomination', '', '', 'Academy_Application'],
                     ['30601', '', 'note', '', '', '', 'Academy Nomination acceptance', '', '', 'Academy_Application'],
                     ['30602', 'Military', '', '', '', '', 'ACADEMY NOMINATION', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_academy")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
@@ -157,7 +157,7 @@ class MyTestCase(unittest.TestCase):
                     ['30603', 'Arts', 'Note', '', '', 'Arts', 'Academy Note', '', '', 'Academy_Application'],
                     ['30604', 'Science', '', '', '', 'Science', 'International Science Academy', '', '',
                      'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_academy_check")
 
     def test_out_topic(self):
         """Test for when column out_topic contains one of the topics indicating academy applications"""
@@ -179,7 +179,7 @@ class MyTestCase(unittest.TestCase):
                      'Academy_Application'],
                     ['30603', '', '', '', '', 'Academy APPLICANT^Military', '', '', '', 'Academy_Application'],
                     ['30604', '', '', '', '', 'Academy Applicant', '', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_academy")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
@@ -187,7 +187,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Transportation', '', '', '', 'Academy', '', '', '', 'Academy_Application'],
                     ['30602', 'General', '', '', '', 'Science Academy', 'Note', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_academy_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_find_appraisal_rows.py
+++ b/tests/css_archiving_format/test_find_appraisal_rows.py
@@ -49,7 +49,7 @@ class MyTestCase(unittest.TestCase):
                     ['30603', 'Admin', '', '', '', 'Recommendations', 'wrote recommendation', '', '', 'Recommendation'],
                     ['30604', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework'],
                     ['30605', 'Intern', '', r'..\doc\resume.txt', '', '', 'job request', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for four categories, df")
+        self.assertEqual(expected, result, "Problem with test for four categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -64,7 +64,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'Casework'],
                     [30605, 'Intern', 'BLANK', r'..\doc\resume.txt', 'BLANK', 'BLANK', 'job request', 'BLANK',
                      'BLANK', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
@@ -78,7 +78,7 @@ class MyTestCase(unittest.TestCase):
                      'Job_Application'],
                     [30607, 'Legislation', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Recommendation noted', 'BLANK',
                      'BLANK', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal check log")
 
     def test_three(self):
         """Test for when there are three categories for appraisal (academy applications, casework, job application)"""
@@ -101,7 +101,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'Casework', '', '', '', '', '', '', '', 'Casework'],
                     ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework'],
                     ['30604', 'Intern', '', '', '', 'job request', '', r'..\doc\resume.txt', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for three categories, df")
+        self.assertEqual(expected, result, "Problem with test for three categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -114,7 +114,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'Casework'],
                     [30604, 'Intern', 'BLANK', 'BLANK', 'BLANK', 'job request', 'BLANK', r'..\doc\resume.txt',
                      'BLANK', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for three categories, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for three categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
@@ -122,7 +122,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     [30605, 'Judicial', 'Napster case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'Casework']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal check log")
 
     def test_two(self):
         """Test for when there are two categories for appraisal (academy applications and casework)"""
@@ -144,7 +144,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Academy Applicant', 'Nomination', '', '', '', '', '', '', 'Academy_Application'],
                     ['30601', 'Casework', '', '', '', '', '', '', '', 'Casework'],
                     ['30603', 'Social Security', 'Casework candidate', '', '', '', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for two categories, df")
+        self.assertEqual(expected, result, "Problem with test for two categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -155,7 +155,7 @@ class MyTestCase(unittest.TestCase):
                     [30601, 'Casework', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Casework'],
                     [30603, 'Social Security', 'Casework candidate', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for two categories, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for two categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
@@ -165,7 +165,7 @@ class MyTestCase(unittest.TestCase):
                      'Academy_Application'],
                     [30605, 'Farming', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK', r'..\doc\case\file.doc', 'BLANK',
                      'Casework']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal check log")
 
     def test_one(self):
         """Test for when there is one category for appraisal (casework)"""
@@ -186,7 +186,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Casework Issues', '', '', '', 'Casework', '', '', '', 'Casework'],
                     ['30601', 'Health^Casework', 'Note', '', '', '', '', '', '', 'Casework'],
                     ['30603', 'Social Security', 'Open Case', '', '', '', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one category, df")
+        self.assertEqual(expected, result, "Problem with test for one category, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -198,14 +198,14 @@ class MyTestCase(unittest.TestCase):
                      'Casework'],
                     [30603, 'Social Security', 'Open Case', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'BLANK',
                      'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one category, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for one category, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     [30604, 'Admin', 'BLANK', 'BLANK', 'BLANK', 'BLANK', 'For Casey', 'BLANK', 'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal check log")
 
     def test_none(self):
         """Test for when there are no indicators for appraisal"""
@@ -220,19 +220,19 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(appraisal_df)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for no appraisal, df")
+        self.assertEqual(expected, result, "Problem with test for no appraisal, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for no appraisal, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for no appraisal, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal check log")
 
     def test_multiple(self):
         """Test for when there are rows that match multiple categories for appraisal"""
@@ -251,7 +251,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Casework^Academy Applicant', '', '', '', '', '', '', '', 'Academy_Application|Casework'],
                     ['30601', 'Academy Applicant', 'Maybe casework', '', '', '', 'rec for doe', '', '',
                      'Academy_Application|Casework|Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for multiple categories, df")
+        self.assertEqual(expected, result, "Problem with test for multiple categories, df")
 
         # Tests the values in the appraisal delete log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -261,7 +261,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'Academy_Application|Casework'],
                     [30601, 'Academy Applicant', 'Maybe casework', 'BLANK', 'BLANK', 'BLANK', 'rec for doe', 'BLANK',
                      'BLANK', 'Academy_Application|Casework|Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for four categories, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for four categories, appraisal delete log")
 
         # Tests the values in the appraisal check log are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
@@ -275,7 +275,7 @@ class MyTestCase(unittest.TestCase):
                      'Job_Application'],
                     [30603, 'Admin', 'note', r'doc\case.txt', 'BLANK', 'Admin', 'recommendation', 'BLANK', 'BLANK',
                      'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for multiple categories, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for multiple categories, appraisal check log")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_find_casework_rows.py
+++ b/tests/css_archiving_format/test_find_casework_rows.py
@@ -36,7 +36,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'SSA', '', '', '', 'SSA', 'Jan added to case', '', 'case Jan', 'Casework'],
                     ['30603', 'Health', '', '', '', '', 'open case', '', '', 'Casework'],
                     ['30604', '', '', '', '', 'Admin', 'Started case Wed', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for all casework, df_casework")
+        self.assertEqual(expected, result, "Problem with test for all casework, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
@@ -44,7 +44,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30606', 'Admin', 'new case', '', '', 'Admin', 'note', '', 'thank you_case', 'Casework'],
                     ['30607', 'Admin', 'note', '', '', '', '', r'case\file.txt', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for all casework, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for all casework, df_casework_check")
 
     def test_in_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
@@ -73,14 +73,14 @@ class MyTestCase(unittest.TestCase):
                     ['30605', 'casework issues^Social Security', '', '', '', 'SSA', 'note', '', '', 'Casework'],
                     ['30606', 'Prison Case^No Reply', '', '', '', 'Justice', '', '', '', 'Casework'],
                     ['30608', 'Casework^Casework Issues', '', '', '', 'Admin', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_casework")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30607', 'Keep', '', '', '', 'Legal', 'CASE OF THE CENTURY', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_casework_check")
 
     def test_none(self):
         """Test for when there are no indicators of casework"""
@@ -95,13 +95,13 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_casework)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_casework_check")
 
     def test_out_text(self):
         """Test for when the column out_text is equal to a keyword that indicates casework"""
@@ -124,7 +124,7 @@ class MyTestCase(unittest.TestCase):
                     ['30602', 'Admin', '', '', '', '', 'CASE', '', '', 'Casework'],
                     ['30604', '', '', '', '', '', 'case!', '', '', 'Casework'],
                     ['30606', '', '', '', '', '', 'case', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_casework")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
@@ -132,7 +132,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30603', '', '', '', '', '', 'Not case', '', '', 'Casework'],
                     ['30605', '', '', '', '', 'Admin', 'Just in case', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_casework_check")
 
     def test_out_topic(self):
         """Test for when the column in_topic contains a topic that indicates casework"""
@@ -156,13 +156,13 @@ class MyTestCase(unittest.TestCase):
                     ['30602', 'SSA', '', '', '', 'Casework Issues^Social Security', 'note', '', '', 'Casework'],
                     ['30603', '', '', '', '', 'Prison Case', '', '', '', 'Casework'],
                     ['30604', '', '', '', '', 'casework^casework Issues', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_casework")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_casework_check")
 
     def test_phase(self):
         """Test for when a column contains a phrase that indicates casework"""
@@ -200,14 +200,14 @@ class MyTestCase(unittest.TestCase):
                     ['30608', 'Closed Case', '', '', '', '', '', '', '', 'Casework'],
                     ['30609', 'Open Case', '', '', '', '', '', '', '', 'Casework'],
                     ['30610', '', '', '', '', 'Admin', 'Mary started case yesterday', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for phrase, df_casework")
+        self.assertEqual(expected, result, "Problem with test for phrase, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30611', 'Roads', '', '', '', '', 'Not a case', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for phrase, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for phrase, df_casework_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_find_job_rows.py
+++ b/tests/css_archiving_format/test_find_job_rows.py
@@ -37,13 +37,13 @@ class MyTestCase(unittest.TestCase):
                      '', 'Job_Application'],
                     ['30605', 'Admin', 'job request', '', '', 'Resume', '', r'..\doc\resume.txt', '', 'Job_Application'],
                     ['30604', '', 'Job Request', '', '', '', 'job request', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_job")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_job_check")
 
     def test_in_document_name(self):
         """Test for when column in_document_name contains a word or phrase indicating job applications"""
@@ -65,7 +65,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Admin', '', r'..\doc\Doe Job Interview.txt', '', '', '', '', '', 'Job_Application'],
                     ['30602', 'Admin', '', r'..\doc\resume.txt', '', 'Admin', 'Files', '', '', 'Job_Application'],
                     ['30605', '', '', r'..\doc\jobs\Resume_Regret.doc', '', '', 'Note', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_document_name, df_job")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
@@ -73,7 +73,7 @@ class MyTestCase(unittest.TestCase):
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30601', 'Arts', '', r'..\doc\job_file.txt', '', '', '', '', '', 'Job_Application'],
                     ['30604', '', '', r'..\doc\jobs\file.doc', '', '', 'Note', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, df_job_check")
 
     def test_in_text(self):
         """Test for when column in_text contains a word or phrase indicating job applications"""
@@ -99,14 +99,14 @@ class MyTestCase(unittest.TestCase):
                     ['30602', '', 'Job Request', '', '', '', '', '', '', 'Job_Application'],
                     ['30605', '', 'resume', '', '', '', '', '', '', 'Job_Application'],
                     ['30606', '', 'Forwarded Resume', '', '', '', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_job")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30603', 'Arts', 'Freelance job', '', '', '', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_job_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains one of the topics indicating job applications"""
@@ -129,14 +129,14 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'Admin^RESUMES', '', '', '', '', 'Note', '', '', 'Job_Application'],
                     ['30603', 'Resumes', '', '', '', 'Economy', '', '', '', 'Job_Application'],
                     ['30604', 'intern', '', '', '', '', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_job")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30605', 'Job Hunting', '', '', '', '', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_job_check")
 
     def test_none(self):
         """Test for when no patterns indicating job applications are present"""
@@ -152,13 +152,13 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_job)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_job")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text',
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_job_check")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_job_check")
 
     def test_out_document_name(self):
         """Test for when column out_document_name contains a word or phrase indicating job applications"""
@@ -180,7 +180,7 @@ class MyTestCase(unittest.TestCase):
                     ['30600', 'Admin', '', '', '', '', '', r'..\doc\Doe Job Interview.txt', '', 'Job_Application'],
                     ['30602', 'Admin', '', '', '', 'Admin', 'Files', r'..\doc\resume.txt', '', 'Job_Application'],
                     ['30605', '', '', '', '', '', 'Note', r'..\doc\jobs\Resume_Regret.doc', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_document_name, df_job")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
@@ -188,7 +188,7 @@ class MyTestCase(unittest.TestCase):
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30601', 'Arts', '', '', '', '', '', r'..\doc\job_file.txt', '', 'Job_Application'],
                     ['30604', '', '', '', '', '', 'Note', r'..\doc\jobs\file.doc', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_document_name, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for out_document_name, df_job_check")
 
     def test_out_text(self):
         """Test for when column out_text contains a word or phrase indicating job applications"""
@@ -213,7 +213,7 @@ class MyTestCase(unittest.TestCase):
                     ['30604', 'Admin', '', '', '', '', 'job request - accept', '', '', 'Job_Application'],
                     ['30605', 'Admin', '', '', '', '', 'Doe resume', '', '', 'Job_Application'],
                     ['30606', 'Admin', '', '', '', '', 'RESUME', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_job")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
@@ -221,7 +221,7 @@ class MyTestCase(unittest.TestCase):
                      'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', 'Farms', '', '', '', 'Agriculture', 'Job numbers', '', '', 'Job_Application'],
                     ['30602', '', '', '', '', 'Economy', '', 'Jobs report', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_job_check")
 
     def test_out_topic(self):
         """"Test for when column out_topic contains one of the topics indicating job applications"""
@@ -244,13 +244,13 @@ class MyTestCase(unittest.TestCase):
                     ['30602', '', '', '', '', 'Intern', '', '', '', 'Job_Application'],
                     ['30603', '', '', '', '', 'INTERN^Admin', 'note', '', '', 'Job_Application'],
                     ['30605', '', '', '', '', 'Resumes', 'note', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_job")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_topic', 'out_text', 
                      'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_job_check")
 
         
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_find_recommendation_rows.py
+++ b/tests/css_archiving_format/test_find_recommendation_rows.py
@@ -42,7 +42,7 @@ class MyTestCase(unittest.TestCase):
                     ['30604', '', '', '', '', 'Admin^Recommendations', 'wrote recommendation', '', '', 'Recommendation'],
                     ['30601', '', 'rec for john doe', '', '', '', 'policy for recommendations sent', '', '',
                      'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
@@ -51,7 +51,7 @@ class MyTestCase(unittest.TestCase):
                     ['30605', 'Admin', 'my recommendation is x', '', '', 'Admin', '', '', '', 'Recommendation'],
                     ['30606', 'Admin', 'note', '', '', 'Admin', 'recommendation', r'doc\recommendation.txt',
                      'name_date', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for all patterns, df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for all patterns, df_recommendations_check")
 
     def test_in_text(self):
         """Test for when column in_text contains a phrase indicating recommendations"""
@@ -74,14 +74,14 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'Admin', 'policy for recommendations sent', '', '', 'Admin', '', '', '', 'Recommendation'],
                     ['30603', 'General', 'Letter of Recommendation', '', '', '', '', '', '', 'Recommendation'],
                     ['30604', '', 'Requested rec for JD', '', '', '', '', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30602', 'Arts', 'Program recommendation', '', '', '', '', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for in_text, df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for in_text, df_recommendations_check")
 
     def test_in_topic(self):
         """Test for when column in_topic contains Recommendations"""
@@ -103,13 +103,13 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'Admin^recommendations', '', '', '', '', '', '', '', 'Recommendation'],
                     ['30602', 'RECOMMENDATIONS^Admin', '', '', '', '', '', '', '', 'Recommendation'],
                     ['30603', 'Policy Recommendation', '', '', '', 'Water', 'Reply note', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for in_topic, df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for in_topic, df_recommendations_check")
 
     def test_none(self):
         """Test for when no patterns indicating recommendations are present"""
@@ -124,13 +124,13 @@ class MyTestCase(unittest.TestCase):
         result = df_to_list(df_recommendations)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
         expected = [['zip', 'in_topic', 'in_text', 'in_document_name', 'in_fillin',
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none (no patterns matched), df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for none (no patterns matched), df_recommendations_check")
 
     def test_out_text(self):
         """Test for when column out_text contains a phrase indicating recommendations"""
@@ -153,7 +153,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'Admin', 'note', '', '', '', 'Policy for recommendations sent', '', '', 'Recommendation'],
                     ['30602', 'Admin', 'note', '', '', '', 'REC FOR JD', '', '', 'Recommendation'],
                     ['30605', 'Admin', '', '', '', '', 'Wrote Recommendation', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
@@ -161,7 +161,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30603', 'Admin', '', '', '', '', 'not a recommendation', '', '', 'Recommendation'],
                     ['30604', 'Admin', '', '', '', '', 'recommendation to support', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for out_text, df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for out_text, df_recommendations_check")
 
     def test_out_topic(self):
         """Test for when column out_topic contains Recommendations"""
@@ -182,7 +182,7 @@ class MyTestCase(unittest.TestCase):
                     ['30601', 'General', '', '', '', 'General^recommendations', '', '', '', 'Recommendation'],
                     ['30603', '', 'note', '', '', 'RECOMMENDATIONS', '', '', '', 'Recommendation'],
                     ['30604', 'Admin', '', '', '', 'Recommendations^Admin', 'note', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_recommendations")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_recommendations")
 
         # Tests the values in df_recommendations_check are correct.
         result = df_to_list(df_recommendations_check)
@@ -190,7 +190,7 @@ class MyTestCase(unittest.TestCase):
                      'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category'],
                     ['30600', '', '', '', '', 'Water', 'Policy Recommendation', '', '', 'Recommendation'],
                     ['30602', 'Water', '', '', '', '', 'Recommendation', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for out_topic, df_recommendations_check")
+        self.assertEqual(expected, result, "Problem with test for out_topic, df_recommendations_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_read_metadata.py
+++ b/tests/css_archiving_format/test_read_metadata.py
@@ -34,7 +34,7 @@ class MyTestCase(unittest.TestCase):
                     ['Mr.', 'Bill', 'B.', 'Blue', 'blank', 'blank', 'blank', 'blank', '456 B St', 'Apt 7', 'blank',
                      'blank', 'B city', 'WY', '23456', 'blank', 'b200', 'Case', 'Email', '20240202', 'B1^B2', 'Note',
                      'fileB200', 'blank', 'r200', 'Case', 'Email', '20240212', 'formB', 'blank', 'replyB200', 'blank']]
-        self.assertEqual(result, expected, "Problem with test for correct")
+        self.assertEqual(expected, result, "Problem with test for correct")
 
     def test_correct_blanks(self):
         """Test for when the DAT file can be read in its entirety but has blank rows to skip"""
@@ -53,7 +53,7 @@ class MyTestCase(unittest.TestCase):
                     ['Mr.', 'Bill', 'B.', 'Blue', 'blank', 'blank', 'blank', 'blank', '456 B St', 'Apt 7', 'blank',
                      'blank', 'B city', 'WY', '23456', 'blank', 'b200', 'Case', 'Email', '20240202', 'B1^B2', 'Note',
                      'fileB200', 'blank', 'r200', 'Case', 'Email', '20240212', 'formB', 'blank', 'replyB200', 'blank']]
-        self.assertEqual(result, expected, "Problem with test for correct - blanks")
+        self.assertEqual(expected, result, "Problem with test for correct - blanks")
 
     def test_parser_error(self):
         """Test for when the DAT file has content with tabs, resulting in a ParserError
@@ -77,7 +77,7 @@ class MyTestCase(unittest.TestCase):
                      'blank', 'blank', 'D city', 'DE', '45678', 'blank', 'd400', 'General', 'Email', '20240404', 'D1',
                      'blank', 'fileD400', 'blank', 'r400', 'General', 'Email', '20240414', 'formD', 'blank',
                      'replyD400', 'blank']]
-        self.assertEqual(result, expected, "Problem with test for ParserError")
+        self.assertEqual(expected, result, "Problem with test for ParserError")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_remove_appraisal_rows.py
+++ b/tests/css_archiving_format/test_remove_appraisal_rows.py
@@ -30,7 +30,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['last', 'title', 'zip', 'in_type', 'in_document_name'],
                     ['Blue', '', '23456', 'Issue', r'..\objects\222222.txt'],
                     ['Dudley', '', '45678', 'Issue', '']]
-        self.assertEqual(result, expected, "Problem with test for type different")
+        self.assertEqual(expected, result, "Problem with test for type different")
 
     def test_type_same(self):
         """Test for when columns in md_df have the same datatype and value as appraisal_df"""
@@ -52,7 +52,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['last', 'title', 'zip', 'in_type', 'in_document_name'],
                     ['Blue', '', '23456', 'Issue', r'..\objects\222222.txt'],
                     ['Dudley', '', '45678', 'Issue', '']]
-        self.assertEqual(result, expected, "Problem with test for same type")
+        self.assertEqual(expected, result, "Problem with test for same type")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_remove_pii.py
+++ b/tests/css_archiving_format/test_remove_pii.py
@@ -22,11 +22,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['city', 'state', 'zip', 'in_id', 'out_id']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for all present, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for all present, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['13', '14', '15', '16', '19']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for all present, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for all present, values")
 
     def test_some_present(self):
         """Test for when some PII columns are present."""
@@ -37,11 +37,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['in_type', 'country']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for some present, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for some present, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['1', '5']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for some present, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for some present, values")
 
     def test_none_present(self):
         """Test for when no PII columns are present."""
@@ -52,11 +52,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['zip', 'country', 'in_id', 'out_id']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for none present, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for none present, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['1', '2', '3', '4'], ['11', '12', '13', '14']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for none present, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for none present, values")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -70,7 +70,7 @@ class MyTestCase(unittest.TestCase):
         expected = ("\nThe script is running in access mode.\nIt will remove rows for deleted letters "
                     "and columns with PII, make copies of the metadata split by congress year, and make a copy "
                     "of the constituent letters organized by topic\n")
-        self.assertEqual(result, expected, "Problem with test for access, printed statement")
+        self.assertEqual(expected, result, "Problem with test for access, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -79,7 +79,7 @@ class MyTestCase(unittest.TestCase):
                      'addr3', 'addr4', 'city', 'state', 'zip', 'country', 'in_id', 'in_type', 'in_method', 'in_date',
                      'in_topic', 'in_text', 'in_document_name', 'in_fillin', 'out_id', 'out_type', 'out_method',
                      'out_date', 'out_topic', 'out_text', 'out_document_name', 'out_fillin', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal check log")
 
         # Tests the contents of the appraisal delete log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -97,7 +97,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'E city', 'ME', 56789, 'BLANK', 'e100', 'General', 'Email', 20210101, 'Casework Issues',
                      'BLANK', r'..\documents\BlobExport\objects\555555.txt', 'BLANK', 'r500', 'General', 'Email',
                      20210111, 'E', 'BLANK', r'..\documents\BlobExport\indivletters\000005.txt', 'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal delete log")
 
         # Tests the contents of archiving_correspondence_redacted.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_redacted.csv')
@@ -114,7 +114,7 @@ class MyTestCase(unittest.TestCase):
                     ['C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'A1',
                      r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', 20240313,
                      'A', r'..\documents\BlobExport\formletters\A']]
-        self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
+        self.assertEqual(expected, result, "Problem with test for access, archiving_correspondence_redacted.csv")
 
         # Tests the contents of 2021-2022.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '2021-2022.csv')
@@ -125,7 +125,7 @@ class MyTestCase(unittest.TestCase):
                     ['A city', 'AL', 12345, 'BLANK', 'a100', 'General', 'Email', 20210101, 'A1',
                      r'..\documents\BlobExport\objects\111111.txt', 'r100', 'General', 'Email', 20210111,
                      'A', r'..\documents\BlobExport\formletters\A']]
-        self.assertEqual(result, expected, "Problem with test for access, 2021-2022.csv")
+        self.assertEqual(expected, result, "Problem with test for access, 2021-2022.csv")
 
         # Tests the contents of 2023-2024.csv.
         csv_path = os.path.join(os.getcwd(), 'test_data', 'script', 'archiving_correspondence_by_congress_year', '2023-2024.csv')
@@ -139,19 +139,19 @@ class MyTestCase(unittest.TestCase):
                     ['C city', 'CO', 34567, 'BLANK', 'c300', 'General', 'Letter', 20240303, 'A1',
                      r'..\documents\BlobExport\objects\333333.txt', 'r300', 'General', 'Email', 20240313,
                      'A', r'..\documents\BlobExport\formletters\A']]
-        self.assertEqual(result, expected, "Problem with test for access, 2023-2024.csv")
+        self.assertEqual(expected, result, "Problem with test for access, 2023-2024.csv")
 
         # Tests that no undated.csv was made.
         result = os.path.exists(os.path.join(os.getcwd(), 'test_data', 'script',
                                              'archiving_correspondence_by_congress_year', 'undated.csv'))
-        self.assertEqual(result, False, "Problem with test for access, undated.csv")
+        self.assertEqual(False, result, "Problem with test for access, undated.csv")
 
         # Tests that Correspondence_by_Topic has the expected files.
         by_topic = os.path.join(os.getcwd(), 'test_data', 'script', 'Correspondence_by_Topic')
         result = make_dir_list(by_topic)
         expected = [os.path.join(by_topic, 'A1', '111111.txt'), os.path.join(by_topic, 'A1', '333333.txt'),
                     os.path.join(by_topic, 'B1', '222222.txt'), os.path.join(by_topic, 'B2', '222222.txt')]
-        self.assertEqual(result, expected, "Problem with test for access, Correspondence_by_Topic")
+        self.assertEqual(expected, result, "Problem with test for access, Correspondence_by_Topic")
 
         # Tests the other script mode outputs were not made.
         output_directory = os.path.join('test_data', 'script')
@@ -168,7 +168,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join(output_directory, 'usability_report_matching_details.csv')),
                   os.path.exists(os.path.join(output_directory, 'usability_report_metadata.csv'))]
         expected = [False, False, False, False, False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for access, other script mode outputs")
+        self.assertEqual(expected, result, "Problem with test for access, other script mode outputs")
 
     def test_correct_accession(self):
         """Test for when the script runs correctly and is in accession mode."""
@@ -186,7 +186,7 @@ class MyTestCase(unittest.TestCase):
         result = printed.stdout
         expected = ("\nThe script is running in accession mode.\n"
                     "It will produce usability and appraisal reports and not change the export.\n")
-        self.assertEqual(result, expected, "Problem with test for accession, printed statement")
+        self.assertEqual(expected, result, "Problem with test for accession, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -199,7 +199,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'G city', 'GA', 78901, 'BLANK', 'g100', 'General', 'Email', 20210101, 'E', 'BLANK',
                      r'..\documents\BlobExport\objects\777777.txt', 'BLANK', 'r700', 'General', 'Email', 20210111,
                      'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for accession, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for accession, appraisal check log")
 
         # Tests the contents of the appraisal delete log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -232,7 +232,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
                      'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', '20210111',
                      'E', 'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for accession, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for accession, appraisal delete log")
 
         # Tests the contents of metadata_formatting_errors_state.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_state.csv')
@@ -249,7 +249,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
                      'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', 20210111, 'E',
                      'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_state.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_state.csv")
 
         # Tests the contents of metadata_formatting_errors_out_date.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_out_date.csv')
@@ -263,8 +263,7 @@ class MyTestCase(unittest.TestCase):
                      'Maybe casework', r'..\documents\BlobExport\objects\333333.txt', 'BLANK', 'r300', 'General',
                      'Email', '2024-03-13', 'B1^B2', 'BLANK', r'..\documents\BlobExport\indivletters\000003.txt', 
                      'BLANK']]
-        self.assertEqual(result, expected,
-                         "Problem with test for accession, metadata_formatting_errors_out_date.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_out_date.csv")
 
         # Tests the other metadata formatting reports were not made.
         output_directory = os.path.join('test_data', 'script')
@@ -273,7 +272,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join(output_directory, 'metadata_formatting_errors_in_doc.csv')),
                   os.path.exists(os.path.join(output_directory, 'metadata_formatting_errors_out_doc.csv'))]
         expected = [False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for accession, other metadata formatting reports")
+        self.assertEqual(expected, result, "Problem with test for accession, other metadata formatting reports")
 
         # Tests the contents of topics_report.csv.
         csv_path = os.path.join('test_data', 'script', 'topics_report.csv')
@@ -286,7 +285,7 @@ class MyTestCase(unittest.TestCase):
                     ['Misc', 2, 0, 2],
                     ['Recommendations', 1, 1, 2],
                     ['Social Security^Casework', 1, 0, 1]]
-        self.assertEqual(result, expected, "Problem with test for accession, topics_report.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, topics_report.csv")
 
         # Tests the contents of usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
@@ -296,7 +295,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', 3, '21%'],
                     ['Metadata_Blank', 1, '7%'],
                     ['Directory_Only', 2, 'BLANK']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of usability_report_matching_details.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching_details.csv')
@@ -307,7 +306,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\444444.txt'],
                     ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\555555.txt'],
                     ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\b.txt']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching_details.csv")
 
         # Tests the contents of usability_report_metadata.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_metadata.csv')
@@ -345,7 +344,7 @@ class MyTestCase(unittest.TestCase):
                     ['out_text', True, 7, 100.0, 'uncheckable'],
                     ['out_document_name', True, 0, 0.0, '0'],
                     ['out_fillin', True, 6, 85.71, 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_metadata.csv")
 
         # Tests the other script mode outputs were not made.
         output_directory = os.path.join('test_data', 'script')
@@ -355,7 +354,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join(output_directory, 'archiving_correspondence_redacted.csv')),
                   os.path.exists(os.path.join(output_directory, f'file_deletion_log_{today}.csv'))]
         expected = [False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for accession, other script mode outputs")
+        self.assertEqual(expected, result, "Problem with test for accession, other script mode outputs")
 
     def test_correct_appraisal(self):
         """Test for when the script runs correctly and is in appraisal mode."""
@@ -373,7 +372,7 @@ class MyTestCase(unittest.TestCase):
         result = printed.stdout
         expected = ("\nThe script is running in appraisal mode.\n"
                     "It will delete letters due to appraisal but not change the metadata file.\n")
-        self.assertEqual(result, expected, "Problem with test for appraisal, printed statement")
+        self.assertEqual(expected, result, "Problem with test for appraisal, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -386,7 +385,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'G city', 'GA', 78901, 'BLANK', 'g100', 'General', 'Email', 20210101, 'E', 'BLANK',
                      r'..\documents\BlobExport\objects\777777.txt', 'BLANK', 'r700', 'General', 'Email', 20210111,
                      'BLANK', 'BLANK', r'..\documents\BlobExport\indivletters\000007.txt', 'Court case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal check log")
 
         # Tests the contents of the appraisal delete log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -419,7 +418,7 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'F city', 'fl', 67890, 'BLANK', 'f100', 'General', 'Email', 20210101,
                      'Social Security^Casework', 'BLANK', 'BLANK', 'BLANK', 'r600', 'General', 'Email', '20210111',
                      'E', 'BLANK', r'..\documents\BlobExport\formletters\F.txt', 'BLANK', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal delete log")
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
@@ -440,13 +439,13 @@ class MyTestCase(unittest.TestCase):
                      'BLANK', 'BLANK', 'BLANK', 'BLANK', 'Cannot delete: FileNotFoundError'],
                     [r'..\documents\indivletters\000005.txt'.replace('..', input_directory),
                      1.2, today, today, 'EFBB58E35027F2382E2C58F22B895B7C', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for appraisal, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['archiving_correspondence.dat', 'B.txt', 'D.txt', 'F.txt', '000007.txt',
                     '222222.txt', '666666.txt', '777777.txt']
-        self.assertEqual(result, expected, "Problem with test for appraisal, input_directory contents")
+        self.assertEqual(expected, result, "Problem with test for appraisal, input_directory contents")
 
         # Tests the other script mode outputs were not made.
         output_directory = os.path.join('test_data', 'script')
@@ -464,7 +463,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join(output_directory, 'usability_report_matching_details.csv')),
                   os.path.exists(os.path.join(output_directory, 'usability_report_metadata.csv'))]
         expected = [False, False, False, False, False, False, False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for appraisal, other script mode outputs")
+        self.assertEqual(expected, result, "Problem with test for appraisal, other script mode outputs")
 
     def test_correct_preservation(self):
         """Test for when the script runs correctly and is in preservation mode."""
@@ -481,7 +480,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the printed statement.
         result = printed.stdout
         expected = "\nThe script is running in preservation mode.\nThe steps are TBD.\n"
-        self.assertEqual(result, expected, "Problem with test for preservation, printed statement")
+        self.assertEqual(expected, result, "Problem with test for preservation, printed statement")
 
         # Tests the other script mode outputs were not made.
         output_directory = os.path.join('test_data', 'script')
@@ -501,7 +500,7 @@ class MyTestCase(unittest.TestCase):
                   os.path.exists(os.path.join(output_directory, 'usability_report_matching_details.csv')),
                   os.path.exists(os.path.join(output_directory, 'usability_report_metadata.csv'))]
         expected = [False, False, False, False, False, False, False, False, False, False, False, False, False, False]
-        self.assertEqual(result, expected, "Problem with test for preservation, other script mode outputs")
+        self.assertEqual(expected, result, "Problem with test for preservation, other script mode outputs")
 
     def test_error_argument(self):
         """Test for when the script exits due to an argument error."""
@@ -515,7 +514,7 @@ class MyTestCase(unittest.TestCase):
         output = subprocess.run(f"python {script_path}", shell=True, stdout=subprocess.PIPE)
         result = output.stdout.decode('utf-8')
         expected = "Missing required arguments, input_directory and script_mode\r\n"
-        self.assertEqual(result, expected, "Problem with test for error argument, printed error")
+        self.assertEqual(expected, result, "Problem with test for error argument, printed error")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_script.py
+++ b/tests/css_archiving_format/test_script.py
@@ -291,22 +291,22 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
         result = csv_to_list(csv_path)
-        expected = [['Category', 'Count'],
-                    ['Metadata_Only', 3],
-                    ['Directory_Only', 2],
-                    ['Match', 10],
-                    ['Metadata_Blank', 1]]
+        expected = [['Category', 'Row/File_Count', 'Row_Percent'],
+                    ['Match', 10, '71%'],
+                    ['Metadata_Only', 3, '21%'],
+                    ['Metadata_Blank', 1, '7%'],
+                    ['Directory_Only', 2, 'BLANK']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of usability_report_matching_details.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching_details.csv')
         result = csv_to_list(csv_path, sort=True)
         expected = [['Category', 'Path'],
-                    ['Directory Only', r'test_data\script\Accession_Constituent_Mail_Export\documents\formletters\B.txt'],
-                    ['Directory Only', r'test_data\script\Accession_Constituent_Mail_Export\documents\objects\666666.txt'],
-                    ['Metadata Only', r'test_data\script\Accession_Constituent_Mail_Export\documents\objects\444444.txt'],
-                    ['Metadata Only', r'test_data\script\Accession_Constituent_Mail_Export\documents\objects\555555.txt'],
-                    ['Metadata Only', r'test_data\script\Accession_Constituent_Mail_Export\documents\objects\B.txt']]
+                    ['Directory Only', r'test_data\script\accession_constituent_mail_export\documents\formletters\b.txt'],
+                    ['Directory Only', r'test_data\script\accession_constituent_mail_export\documents\objects\666666.txt'],
+                    ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\444444.txt'],
+                    ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\555555.txt'],
+                    ['Metadata Only', r'test_data\script\accession_constituent_mail_export\documents\objects\b.txt']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")
 
         # Tests the contents of usability_report_metadata.csv.

--- a/tests/css_archiving_format/test_sort_correpondence.py
+++ b/tests/css_archiving_format/test_sort_correpondence.py
@@ -66,7 +66,7 @@ class MyTestCase(unittest.TestCase):
         expected = [os.path.join(self.by_topic, 'Agriculture', 'file1.txt'),
                     os.path.join(self.by_topic, 'Agriculture', 'file2.txt'),
                     os.path.join(self.by_topic, 'Peanuts', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for blank")
+        self.assertEqual(expected, result, "Problem with test for blank")
 
     def test_duplicate_file(self):
         """Test for when a file is in the metadata with the same topic more than once"""
@@ -81,7 +81,7 @@ class MyTestCase(unittest.TestCase):
         expected = [os.path.join(self.by_topic, 'Agriculture', 'file1.txt'),
                     os.path.join(self.by_topic, 'Peanuts', 'file1.txt'),
                     os.path.join(self.by_topic, 'Small Business', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_file")
+        self.assertEqual(expected, result, "Problem with test for duplicate_file")
 
     def test_duplicate_topic(self):
         """Test for when a topic is in the metadata more than once, due to topic combinations"""
@@ -99,7 +99,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'Peanuts', 'file2.txt'),
                     os.path.join(self.by_topic, 'Peanuts', 'file3.txt'),
                     os.path.join(self.by_topic, 'Tax', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_topic")
+        self.assertEqual(expected, result, "Problem with test for duplicate_topic")
 
     def test_filenotfounderror(self):
         """Test for when a file is in the metadata but not the directory"""
@@ -114,14 +114,14 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'Agriculture', 'file1.txt'),
                     os.path.join(self.by_topic, 'Peanuts', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, topic folders")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
         expected = [['Agriculture', r'..\documents\BlobExport\file_missing.txt'],
                     ['Peanuts', r'..\documents\BlobExport\file_missing.txt'],
                     ['Peanuts', r'..\documents\BlobExport\folder_missing\file3.txt']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, log")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, log")
 
     def test_folder_empty(self):
         """Test for when no files for a topic are in the directory and the topic folder is empty"""
@@ -135,7 +135,7 @@ class MyTestCase(unittest.TestCase):
         result = [os.path.exists(os.path.join(self.by_topic, 'Agriculture')),
                   os.path.exists(os.path.join(self.by_topic, 'Peanuts'))]
         expected = [False, False]
-        self.assertEqual(result, expected, "Problem with test for folder empty, topic folders")
+        self.assertEqual(expected, result, "Problem with test for folder empty, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
@@ -143,13 +143,13 @@ class MyTestCase(unittest.TestCase):
                     ['Agriculture', r'..\documents\BlobExport\missing\file2.txt'],
                     ['Peanuts', r'..\documents\BlobExport\missing\file2.txt'],
                     ['Peanuts', r'..\documents\BlobExport\missing\file3.txt']]
-        self.assertEqual(result, expected, "Problem with test for folder empty, log")
+        self.assertEqual(expected, result, "Problem with test for folder empty, log")
 
         # Verifies folders without a file are not still present.
         result = [os.path.exists(os.path.join(self.by_topic, 'Agriculture')),
                   os.path.exists(os.path.join(self.by_topic, 'Peanuts'))]
         expected = [False, False]
-        self.assertEqual(result, expected, "Problem with test for folder empty, folders not deleted")
+        self.assertEqual(expected, result, "Problem with test for folder empty, folders not deleted")
 
     def test_folder_name_error(self):
         """Test for when a topic contains a character that cannot be in a folder name"""
@@ -168,7 +168,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, '_H_', 'file2.txt'),
                     os.path.join(self.by_topic, '_I_J_', 'file3.txt'),
                     os.path.join(self.by_topic, '___', 'file1.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name error")
+        self.assertEqual(expected, result, "Problem with test for folder name error")
 
     def test_folder_name_trailing(self):
         """Test for when a topic ends with a space or period, which cannot be in the folder name"""
@@ -183,7 +183,7 @@ class MyTestCase(unittest.TestCase):
         expected = [os.path.join(self.by_topic, 'cat', 'file2.txt'),
                     os.path.join(self.by_topic, 'dog', 'file3.txt'),
                     os.path.join(self.by_topic, 'park and rec', 'file1.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name trailing")
+        self.assertEqual(expected, result, "Problem with test for folder name trailing")
 
     def test_multiple_topic(self):
         """Test for when a row has multiple topics (joined by ^)"""
@@ -201,7 +201,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'Peanuts', 'file2.txt'),
                     os.path.join(self.by_topic, 'Small Business', 'file3.txt'),
                     os.path.join(self.by_topic, 'Tax', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for multiple topic")
+        self.assertEqual(expected, result, "Problem with test for multiple topic")
 
     def test_unique(self):
         """Test for when each topic and file is unique"""
@@ -216,7 +216,7 @@ class MyTestCase(unittest.TestCase):
         expected = [os.path.join(self.by_topic, 'Agriculture', 'file1.txt'),
                     os.path.join(self.by_topic, 'Peanuts', 'file2.txt'),
                     os.path.join(self.by_topic, 'Small Business', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_split_congress_year.py
+++ b/tests/css_archiving_format/test_split_congress_year.py
@@ -36,7 +36,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 19810505, 'oranges', 19810509, 'fruit'],
                     [30603, 19820505, 'oranges', 19820509, 'fruit']]
-        self.assertEqual(result, expected, "Problem with test for all years, 1981-1982")
+        self.assertEqual(expected, result, "Problem with test for all years, 1981-1982")
 
         # Tests that 1987-1988.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1987-1988.csv'))
@@ -44,14 +44,14 @@ class MyTestCase(unittest.TestCase):
                     [30601, 19870104, 'cats', 'BLANK', 'pets'],
                     [30601, 19881001, 'dogs', 19881005, 'BLANK'],
                     [30602, 19881202, 'cats', 19890105, 'pets']]
-        self.assertEqual(result, expected, "Problem with test for all years, 1987-1988")
+        self.assertEqual(expected, result, "Problem with test for all years, 1987-1988")
 
         # Tests that undated.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30602, 'BLANK', 'cats', 19890105, 'pets'],
                     [30603, 'date_error', 'oranges', 19820509, 'fruit']]
-        self.assertEqual(result, expected, "Problem with test for all years, 1987-1988")
+        self.assertEqual(expected, result, "Problem with test for all years, 1987-1988")
 
     def test_date_blank(self):
         """Test for when some of the letters do not have a date (in_date column is blank)"""
@@ -66,7 +66,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 'BLANK', 'dogs', 'BLANK', 'pets'],
                     [30602, 'BLANK', 'cats', 'BLANK', 'pets']]
-        self.assertEqual(result, expected, "Problem with test for date blank, undated")
+        self.assertEqual(expected, result, "Problem with test for date blank, undated")
 
     def test_date_text(self):
         """Test for when data entry errors results in text rather than date (in_date column is a string)"""
@@ -81,7 +81,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30601, 'error', 'cats', 19950105, 'pets'],
                     [30601, 'error_date', 'dogs', 19950105, 'pets']]
-        self.assertEqual(result, expected, "Problem with test for date text, undated")
+        self.assertEqual(expected, result, "Problem with test for date text, undated")
 
     def test_even_years(self):
         """Test for when the letters are from even numbered years"""
@@ -99,13 +99,13 @@ class MyTestCase(unittest.TestCase):
                     [30601, 19900104, 'cats', 19900105, 'pets'],
                     [30601, 19901001, 'dogs', 19901005, 'pets'],
                     [30602, 19901202, 'cats', 19910105, 'pets']]
-        self.assertEqual(result, expected, "Problem with test for even years, 1989-1990")
+        self.assertEqual(expected, result, "Problem with test for even years, 1989-1990")
 
         # Tests that 2001-2002.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2001-2002.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 20020505, 'oranges', 20020509, 'fruit']]
-        self.assertEqual(result, expected, "Problem with test for even years, 2001-2002")
+        self.assertEqual(expected, result, "Problem with test for even years, 2001-2002")
 
     def test_odd_years(self):
         """Test for when the letters are from odd numbered years"""
@@ -123,13 +123,13 @@ class MyTestCase(unittest.TestCase):
                     [30601, 19970104, 'cats', 19970105, 'pets'],
                     [30601, 19971001, 'dogs', 19971005, 'pets'],
                     [30602, 19971202, 'cats', 19980105, 'pets']]
-        self.assertEqual(result, expected, "Problem with test for odd years, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for odd years, 1997-1998")
 
         # Tests that 2009-2010.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2009-2010.csv'))
         expected = [['zip', 'in_date', 'in_topic', 'out_date', 'out_topic'],
                     [30603, 20090505, 'oranges', 20090509, 'fruit']]
-        self.assertEqual(result, expected, "Problem with test for even years, 2009-2010")
+        self.assertEqual(expected, result, "Problem with test for even years, 2009-2010")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_topics_report.py
+++ b/tests/css_archiving_format/test_topics_report.py
@@ -44,7 +44,7 @@ class MyTestCase(unittest.TestCase):
                     ['Puppies', 2, 0, 2],
                     ['Sports', 0, 3, 3],
                     ['Water', 3, 2, 5]]
-        self.assertEqual(result, expected, "Problem with test for all")
+        self.assertEqual(expected, result, "Problem with test for all")
 
     def test_blanks(self):
         """Test for when there are blanks in both topic columns."""
@@ -61,7 +61,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['Topic', 'In_Topic_Count', 'Out_Topic_Count', 'Total'],
                     ['BLANK', 3, 2, 5],
                     ['Water', 1, 2, 3]]
-        self.assertEqual(result, expected, "Problem with test for blanks")
+        self.assertEqual(expected, result, "Problem with test for blanks")
 
     def test_shared(self):
         """Test for when the topics are both the in and out columns."""
@@ -85,7 +85,7 @@ class MyTestCase(unittest.TestCase):
                     ['Puppies', 3, 1, 4],
                     ['Sports', 1, 1, 2],
                     ['Water', 2, 2, 4]]
-        self.assertEqual(result, expected, "Problem with test for shared")
+        self.assertEqual(expected, result, "Problem with test for shared")
 
     def test_unique(self):
         """Test for when the topics are only the in or out columns."""
@@ -103,7 +103,7 @@ class MyTestCase(unittest.TestCase):
                     ['Ecology', 0, 1, 1],
                     ['Sports', 0, 2, 2],
                     ['Water', 2, 0, 2]]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/css_archiving_format/test_update_path.py
+++ b/tests/css_archiving_format/test_update_path.py
@@ -11,25 +11,25 @@ class MyTestCase(unittest.TestCase):
         """Test for the pattern ..\\documents\\BlobExport\\folder\\..\\file.ext"""
         file_path = update_path(r'..\documents\BlobExport\formletters\form_a.txt', 'input_dir')
         expected = r'input_dir\documents\formletters\form_a.txt'
-        self.assertEqual(file_path, expected, "Problem with test for BlobExport")
+        self.assertEqual(expected, file_path, "Problem with test for BlobExport")
 
     def test_dos(self):
         """Test for the pattern \\\\name-office\\dos\\public\\folder\\..\\file.ext"""
         file_path = update_path(r'\\office-dc\dos\public\letter\111111.txt', 'input_dir')
         expected = r'input_dir\documents\letter\111111.txt'
-        self.assertEqual(file_path, expected, "Problem with test for Dos")
+        self.assertEqual(expected, file_path, "Problem with test for Dos")
 
     def test_emailobj(self):
         """Test for the pattern e:\\emailobj\\folder\\file.ext"""
         file_path = update_path(r'e:\emailobj\202112\12345678.txt', 'input_dir')
         expected = r'input_dir\emailobj\202112\12345678.txt'
-        self.assertEqual(file_path, expected, "Problem with test for emailobj")
+        self.assertEqual(expected, file_path, "Problem with test for emailobj")
 
     def test_new(self):
         """Test for a new pattern"""
         file_path = update_path(r'\folder\folder\letter\111111.txt', 'input_dir')
         expected = 'error_new'
-        self.assertEqual(file_path, expected, "Problem with test for new")
+        self.assertEqual(expected, file_path, "Problem with test for new")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_appraisal_check_df.py
+++ b/tests/css_data_interchange_format/test_appraisal_check_df.py
@@ -32,7 +32,7 @@ class MyTestCase(unittest.TestCase):
                     ['20250401', 'Agriculture', r'..\documents\farms_case.txt', 'farms_case.txt', 'case?', 'Casework'],
                     ['20250402', 'Legal Case', r'..\documents\legal_case.txt', 'legal.txt', 'just in case', 'Casework'],
                     ['20250404', 'Case Management', r'..\documents\case.txt', 'case.txt', 'maybe case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for multiple columns")
+        self.assertEqual(expected, result, "Problem with test for multiple columns")
 
     def test_one_column(self):
         """Test for when the keyword is in one column per row"""
@@ -52,7 +52,7 @@ class MyTestCase(unittest.TestCase):
                     ['20250402', 'Legal', r'..\documents\legal_case.txt', 'legal.txt', 'pro', 'Casework'],
                     ['20250404', 'Case Management', r'..\documents\mgt.txt', 'mgt.txt', 'aid', 'Casework'],
                     ['20240405', 'Admin', r'..\documents\file.txt', 'file.txt', 'potential case', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one column")
+        self.assertEqual(expected, result, "Problem with test for one column")
 
     def test_no_column(self):
         """Test for when the keyword is in no columns"""
@@ -65,7 +65,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_check are correct.
         result = df_to_list(df_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for no column")
+        self.assertEqual(expected, result, "Problem with test for no column")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_check_arguments.py
+++ b/tests/css_data_interchange_format/test_check_arguments.py
@@ -22,10 +22,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - access, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - access, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with correct - access, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - access, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - access, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - access, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with correct - access, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - access, errors_list")
 
     def test_correct_accession(self):
         """Test for when both required arguments are present, input_directory path exists and
@@ -40,10 +40,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - accession, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - accession, metadata_paths_dict")
-        self.assertEqual(script_mode, 'accession', "Problem with correct - accession, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - accession, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - accession, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - accession, metadata_paths_dict")
+        self.assertEqual('accession', script_mode, "Problem with correct - accession, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - accession, errors_list")
 
     def test_correct_appraisal(self):
         """Test for when both required arguments are present, input_directory path exists and
@@ -58,10 +58,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - appraisal, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - appraisal, metadata_paths_dict")
-        self.assertEqual(script_mode, 'appraisal', "Problem with correct - appraisal, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - appraisal, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - appraisal, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - appraisal, metadata_paths_dict")
+        self.assertEqual('appraisal', script_mode, "Problem with correct - appraisal, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - appraisal, errors_list")
 
     def test_correct_preservation(self):
         """Test for when both required arguments are present, input_directory path exists and 
@@ -76,10 +76,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with correct - preservation, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with correct - preservation, metadata_paths_dict")
-        self.assertEqual(script_mode, 'preservation', "Problem with correct - preservation, script_mode")
-        self.assertEqual(errors_list, [], "Problem with correct - preservation, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with correct - preservation, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with correct - preservation, metadata_paths_dict")
+        self.assertEqual('preservation', script_mode, "Problem with correct - preservation, script_mode")
+        self.assertEqual([], errors_list, "Problem with correct - preservation, errors_list")
 
     def test_error_input_directory(self):
         """Test for when the input_directory path does not exist"""
@@ -89,10 +89,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with error - input directory, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with error - input directory, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with error - input directory, script_mode")
-        self.assertEqual(errors_list, [f"Provided input_directory '{input_dir}' does not exist"],
+        self.assertEqual(None, input_directory, "Problem with error - input directory, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with error - input directory, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with error - input directory, script_mode")
+        self.assertEqual([f"Provided input_directory '{input_dir}' does not exist"], errors_list,
                          "Problem with error - input directory, errors_list")
 
     def test_error_script_mode(self):
@@ -107,10 +107,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with error - script mode, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with error - script mode, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with error - script mode, script_mode")
-        self.assertEqual(errors_list, ["Provided mode 'mode_error' is not one of the expected modes"],
+        self.assertEqual(input_dir, input_directory, "Problem with error - script mode, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with error - script mode, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with error - script mode, script_mode")
+        self.assertEqual(["Provided mode 'mode_error' is not one of the expected modes"], errors_list,
                          "Problem with error - script mode, errors_list")
 
     def test_missing_both_arg(self):
@@ -120,10 +120,10 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with missing both arguments, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with missing both arguments, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with missing both arguments, script_mode")
-        self.assertEqual(errors_list, ["Missing required arguments, input_directory and script_mode"],
+        self.assertEqual(None, input_directory, "Problem with missing both arguments, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with missing both arguments, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with missing both arguments, script_mode")
+        self.assertEqual(["Missing required arguments, input_directory and script_mode"], errors_list,
                          "Problem with missing both arguments, errors_list")
 
     def test_missing_metadata(self):
@@ -134,14 +134,14 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, input_dir, "Problem with missing metadata, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with missing metadata, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with missing metadata, script_mode")
-        self.assertEqual(errors_list, ['No out_1B.dat file in the input_directory',
-                                       'No out_2A.dat file in the input_directory',
-                                       'No out_2C.dat file in the input_directory',
-                                       'No out_2D.dat file in the input_directory'],
-                         "Problem with missing metadata, errors_list")
+        self.assertEqual(input_dir, input_directory, "Problem with missing metadata, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with missing metadata, metadata_paths_dict")
+        self.assertEqual('access', script_mode, "Problem with missing metadata, script_mode")
+        self.assertEqual(['No out_1B.dat file in the input_directory',
+                          'No out_2A.dat file in the input_directory',
+                          'No out_2C.dat file in the input_directory',
+                          'No out_2D.dat file in the input_directory'],
+                         errors_list, "Problem with missing metadata, errors_list")
 
     def test_missing_metadata_some(self):
         """Test for when some metadata files are in the input_directory"""
@@ -152,13 +152,13 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the value of each of the four variables returned by the function
         expected_dict = {'2A': os.path.join(input_dir, 'out_2A.dat'), '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with missing metadata - some, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict,
+        self.assertEqual(input_dir, input_directory, "Problem with missing metadata - some, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict,
                          "Problem with missing metadata - some, metadata_paths_dict")
-        self.assertEqual(script_mode, 'access', "Problem with missing metadata - some, script_mode")
-        self.assertEqual(errors_list, ['No out_1B.dat file in the input_directory',
-                                       'No out_2C.dat file in the input_directory'],
-                         "Problem with missing metadata - some, errors_list")
+        self.assertEqual('access', script_mode, "Problem with missing metadata - some, script_mode")
+        self.assertEqual(['No out_1B.dat file in the input_directory',
+                          'No out_2C.dat file in the input_directory'],
+                         errors_list, "Problem with missing metadata - some, errors_list")
 
     def test_missing_one_arg(self):
         """Test for when one required argument (script_mode) is missing"""
@@ -172,10 +172,10 @@ class MyTestCase(unittest.TestCase):
                          '2A': os.path.join(input_dir, 'out_2A.dat'),
                          '2C': os.path.join(input_dir, 'out_2C.dat'),
                          '2D': os.path.join(input_dir, 'out_2D.dat')}
-        self.assertEqual(input_directory, input_dir, "Problem with missing one argument, input_directory")
-        self.assertEqual(metadata_paths_dict, expected_dict, "Problem with missing one argument, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with missing one argument, script_mode")
-        self.assertEqual(errors_list, ["Missing one of the required arguments, input_directory or script_mode"],
+        self.assertEqual(input_dir, input_directory, "Problem with missing one argument, input_directory")
+        self.assertEqual(expected_dict, metadata_paths_dict, "Problem with missing one argument, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with missing one argument, script_mode")
+        self.assertEqual(["Missing one of the required arguments, input_directory or script_mode"], errors_list,
                          "Problem with missing one argument, errors_list")
 
     def test_too_many_arg(self):
@@ -186,13 +186,13 @@ class MyTestCase(unittest.TestCase):
         input_directory, metadata_paths_dict, script_mode, errors_list = check_arguments(sys_argv)
 
         # Tests the value of each of the four variables returned by the function
-        self.assertEqual(input_directory, None, "Problem with too many arguments, input_directory")
-        self.assertEqual(metadata_paths_dict, {}, "Problem with too many arguments, metadata_paths_dict")
-        self.assertEqual(script_mode, None, "Problem with too many arguments, script_mode")
-        self.assertEqual(errors_list, [f"Provided input_directory '{input_dir}' does not exist",
-                                       "Provided mode 'mode_error' is not one of the expected modes",
-                                       "Provided more than the required arguments, input_directory and script_mode"],
-                         "Problem with too many arguments, errors_list")
+        self.assertEqual(None, input_directory, "Problem with too many arguments, input_directory")
+        self.assertEqual({}, metadata_paths_dict, "Problem with too many arguments, metadata_paths_dict")
+        self.assertEqual(None, script_mode, "Problem with too many arguments, script_mode")
+        self.assertEqual([f"Provided input_directory '{input_dir}' does not exist",
+                          "Provided mode 'mode_error' is not one of the expected modes",
+                          "Provided more than the required arguments, input_directory and script_mode"],
+                         errors_list, "Problem with too many arguments, errors_list")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_check_letter_matching.py
+++ b/tests/css_data_interchange_format/test_check_letter_matching.py
@@ -43,7 +43,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '4', '57%'],
                     ['Metadata_Blank', '1', '14%'],
                     ['Directory_Only', '3', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for all, summary")
+        self.assertEqual(expected, result, "Problem with test for all, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
@@ -56,7 +56,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata Only', fr'{input_directory.lower()}\documents\201.txt'],
                     ['Metadata Only', fr'{input_directory.lower()}\documents\202.txt'],
                     ['Metadata Only', fr'{input_directory.lower()}\documents\formletters\form_c.txt']]
-        self.assertEqual(result, expected, "Problem with test for all, details")
+        self.assertEqual(expected, result, "Problem with test for all, details")
 
     def test_blanks(self):
         """Test for when the document column includes blanks"""
@@ -81,12 +81,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '3', '38%'],
                     ['Directory_Only', '0', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for blanks, summary")
+        self.assertEqual(expected, result, "Problem with test for blanks, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for blanks, details")
+        self.assertEqual(expected, result, "Problem with test for blanks, details")
 
     def test_directory_only(self):
         """Test for when some file paths are in the directory but not the metadata"""
@@ -105,7 +105,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '3', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, summary")
+        self.assertEqual(expected, result, "Problem with test for directory_only, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
@@ -114,7 +114,7 @@ class MyTestCase(unittest.TestCase):
                     ['Directory Only', fr'{input_directory.lower()}\documents\formletters\form_b.txt'],
                     ['Directory Only', fr'{input_directory.lower()}\documents\objects\part_two\200.txt'],
                     ['Directory Only', fr'{input_directory.lower()}\documents\objects\part_two\300.txt']]
-        self.assertEqual(result, expected, "Problem with test for directory_only, details")
+        self.assertEqual(expected, result, "Problem with test for directory_only, details")
 
     def test_duplicates(self):
         """Test for when the document column includes duplicates"""
@@ -139,12 +139,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for duplicates, summary")
+        self.assertEqual(expected, result, "Problem with test for duplicates, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for duplicates, details")
+        self.assertEqual(expected, result, "Problem with test for duplicates, details")
 
     def test_match(self):
         """Test for when the document column matches the directory contents"""
@@ -166,12 +166,12 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '0', '0%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for match, summary")
+        self.assertEqual(expected, result, "Problem with test for match, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
         expected = [['Category', 'Path']]
-        self.assertEqual(result, expected, "Problem with test for match, details")
+        self.assertEqual(expected, result, "Problem with test for match, details")
 
     def test_metadata_only(self):
         """Test for when some file paths are in the metadata but not the directory"""
@@ -196,7 +196,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '3', '38%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '0', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, summary")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, summary")
 
         # Tests the values in usability_report_matching_details.csv are correct.
         result = csv_to_list(os.path.join(output_directory, 'usability_report_matching_details.csv'))
@@ -205,7 +205,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata Only', fr'{input_directory.lower()}\documents\formletters\form_c.txt'],
                     ['Metadata Only', fr'{input_directory.lower()}\documents\objects\part_two\202.txt'],
                     ['Metadata Only', fr'{input_directory.lower()}\documents\objects\part_two\303.txt']]
-        self.assertEqual(result, expected, "Problem with test for metadata_only, details")
+        self.assertEqual(expected, result, "Problem with test for metadata_only, details")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_check_metadata_formatting.py
+++ b/tests/css_data_interchange_format/test_check_metadata_formatting.py
@@ -44,11 +44,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 'column_blank', "Problem with test for column_blank, count")
+        self.assertEqual('column_blank', zip_mismatch, "Problem with test for column_blank, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_blank, report")
+        self.assertEqual(False, result, "Problem with test for column_blank, report")
 
     def test_column_missing(self):
         """Test for a column that is missing, which would be the same for any column"""
@@ -61,11 +61,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 'column_missing', "Problem with test for column_missing, count")
+        self.assertEqual('column_missing', zip_mismatch, "Problem with test for column_missing, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_missing, report")
+        self.assertEqual(False, result, "Problem with test for column_missing, report")
 
     def test_column_no_errors(self):
         """Test for a column with no formatting errors, which would be the same for any column"""
@@ -77,11 +77,11 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 0, "Problem with test for column_no_errors, count")
+        self.assertEqual(0, zip_mismatch, "Problem with test for column_no_errors, count")
 
         # Tests the report was not created.
         result = os.path.exists(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
-        self.assertEqual(result, False, "Problem with test for column_no_errors, report")
+        self.assertEqual(False, result, "Problem with test for column_no_errors, report")
 
     def test_communication_document_name(self):
         """Test for the communication_document_name column"""
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
         cdm_mismatch = check_metadata_formatting('communication_document_name', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(cdm_mismatch, 4, "Problem with test for communication_document_name, count")
+        self.assertEqual(4, cdm_mismatch, "Problem with test for communication_document_name, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_communication_document_name.csv'))
@@ -106,7 +106,7 @@ class MyTestCase(unittest.TestCase):
                     ['nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'documents\\objects\\2.txt'],
                     ['nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'objects\\3.txt'],
                     ['nan', 'nan', 'nan', 'nan', 'nan', 'nan', '4.txt']]
-        self.assertEqual(result, expected, "Problem with test for communication_document_name, report")
+        self.assertEqual(expected, result, "Problem with test for communication_document_name, report")
 
     def test_date_in(self):
         """Test for the date_in column"""
@@ -121,7 +121,7 @@ class MyTestCase(unittest.TestCase):
         date_in_mismatch = check_metadata_formatting('date_in', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(date_in_mismatch, 3, "Problem with test for date_in, count")
+        self.assertEqual(3, date_in_mismatch, "Problem with test for date_in, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_date_in.csv'))
@@ -130,7 +130,7 @@ class MyTestCase(unittest.TestCase):
                     ['nan', 'nan', '2005', 'nan', 'nan', 'nan', 'nan'],
                     ['nan', 'nan', '2005-01-02', 'nan', 'nan', 'nan', 'nan'],
                     ['nan', 'nan', 'January 2005', 'nan', 'nan', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for date_in, report")
+        self.assertEqual(expected, result, "Problem with test for date_in, report")
 
     def test_date_out(self):
         """Test for the date_out column"""
@@ -145,7 +145,7 @@ class MyTestCase(unittest.TestCase):
         date_out_mismatch = check_metadata_formatting('date_out', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(date_out_mismatch, 2, "Problem with test for date_out, count")
+        self.assertEqual(2, date_out_mismatch, "Problem with test for date_out, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_date_out.csv'))
@@ -153,7 +153,7 @@ class MyTestCase(unittest.TestCase):
                      'communication_document_name'],
                     ['nan', 'nan', 'nan', '2025/12/01', 'nan', 'nan', 'nan'],
                     ['nan', 'nan', 'nan', '2025-12-01', 'nan', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for date_out, report")
+        self.assertEqual(expected, result, "Problem with test for date_out, report")
 
     def test_reminder_date(self):
         """Test for the reminder_date column"""
@@ -168,14 +168,14 @@ class MyTestCase(unittest.TestCase):
         reminder_mismatch = check_metadata_formatting('reminder_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(reminder_mismatch, 1, "Problem with test for reminder_date, count")
+        self.assertEqual(1, reminder_mismatch, "Problem with test for reminder_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_reminder_date.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'date_out', 'reminder_date', 'update_date',
                      'communication_document_name'],
                     ['nan', 'nan', 'nan', 'nan', '2023', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for reminder_date, report")
+        self.assertEqual(expected, result, "Problem with test for reminder_date, report")
 
     def test_state_code(self):
         """Test for the state_code column"""
@@ -190,7 +190,7 @@ class MyTestCase(unittest.TestCase):
         state_mismatch = check_metadata_formatting('state_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(state_mismatch, 3, "Problem with test for state_code, count")
+        self.assertEqual(3, state_mismatch, "Problem with test for state_code, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_state_code.csv'))
@@ -199,7 +199,7 @@ class MyTestCase(unittest.TestCase):
                     ['ga', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan'],
                     ['Georgia', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan'],
                     ['X', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for state_code, report")
+        self.assertEqual(expected, result, "Problem with test for state_code, report")
 
     def test_update_date(self):
         """Test for the update_date column"""
@@ -214,7 +214,7 @@ class MyTestCase(unittest.TestCase):
         update_mismatch = check_metadata_formatting('update_date', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(update_mismatch, 2, "Problem with test for update_date, count")
+        self.assertEqual(2, update_mismatch, "Problem with test for update_date, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_update_date.csv'))
@@ -222,7 +222,7 @@ class MyTestCase(unittest.TestCase):
                      'communication_document_name'],
                     ['nan', 'nan', 'nan', 'nan', 'nan', '202101212', 'nan'],
                     ['nan', 'nan', 'nan', 'nan', 'nan', 'no date', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for update_date, report")
+        self.assertEqual(expected, result, "Problem with test for update_date, report")
 
     def test_zip_code(self):
         """Test for the zip_code column"""
@@ -237,7 +237,7 @@ class MyTestCase(unittest.TestCase):
         zip_mismatch = check_metadata_formatting('zip_code', df, 'test_data')
 
         # Tests the returned row count is correct.
-        self.assertEqual(zip_mismatch, 3, "Problem with test for zip_code, count")
+        self.assertEqual(3, zip_mismatch, "Problem with test for zip_code, count")
 
         # Tests the values in the report are correct.
         result = csv_to_list(os.path.join('test_data', 'metadata_formatting_errors_zip_code.csv'))
@@ -246,7 +246,7 @@ class MyTestCase(unittest.TestCase):
                     ['nan', '30601 1234', 'nan', 'nan', 'nan', 'nan', 'nan'],
                     ['nan', '3060', 'nan', 'nan', 'nan', 'nan', 'nan'],
                     ['nan', 'XXXXX', 'nan', 'nan', 'nan', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for zip_code, report")
+        self.assertEqual(expected, result, "Problem with test for zip_code, report")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_check_metadata_usability.py
+++ b/tests/css_data_interchange_format/test_check_metadata_usability.py
@@ -70,7 +70,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '0', '0.0', 'uncheckable'],
                     ['file_location', 'True', '0', '0.0', 'uncheckable'],
                     ['file_name', 'True', '0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for all correct")
+        self.assertEqual(expected, result, "Problem with test for all correct")
 
     def test_blank(self):
         """Test for when every row is blank"""
@@ -103,7 +103,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '2', '100.0', 'uncheckable'],
                     ['file_location', 'True', '2', '100.0', 'uncheckable'],
                     ['file_name', 'True', '2', '100.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for blank")
+        self.assertEqual(expected, result, "Problem with test for blank")
 
     def test_blank_partial(self):
         """Test for when some rows of each column have blanks but no columns are all blank"""
@@ -138,7 +138,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '1', '33.33', 'uncheckable'],
                     ['file_location', 'True', '1', '33.33', 'uncheckable'],
                     ['file_name', 'True', '1', '33.33', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for blank, partial")
+        self.assertEqual(expected, result, "Problem with test for blank, partial")
 
     def test_columns_extra(self):
         """Test for when there are additional columns beyond what is expected"""
@@ -178,7 +178,7 @@ class MyTestCase(unittest.TestCase):
                     ['status', 'True', '0', '0.0', 'uncheckable'],
                     ['update_date', 'True', '0', '0.0', '0'],
                     ['zip_code', 'True', '0', '0.0', '0']]
-        self.assertEqual(result, expected, "Problem with test for columns extra")
+        self.assertEqual(expected, result, "Problem with test for columns extra")
 
     def test_formatting(self):
         """Test for when each column with formatting tests has errors"""
@@ -213,7 +213,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '0', '0.0', 'uncheckable'],
                     ['file_location', 'True', '0', '0.0', 'uncheckable'],
                     ['file_name', 'True', '0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for formatting")
+        self.assertEqual(expected, result, "Problem with test for formatting")
 
     def test_columns_missing(self):
         """Test for when every column except dates is missing
@@ -244,7 +244,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'False', 'nan', 'nan', 'uncheckable'],
                     ['file_location', 'False', 'nan', 'nan', 'uncheckable'],
                     ['file_name', 'False', 'nan', 'nan', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for columns missing")
+        self.assertEqual(expected, result, "Problem with test for columns missing")
 
     def test_columns_missing_dates(self):
         """Test for when the date columns are missing
@@ -278,7 +278,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '0.0', '0.0', 'uncheckable'],
                     ['file_location', 'True', '0.0', '0.0', 'uncheckable'],
                     ['file_name', 'True', '0.0', '0.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for columns missing dates")
+        self.assertEqual(expected, result, "Problem with test for columns missing dates")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_delete_appraisal_letters.py
+++ b/tests/css_data_interchange_format/test_delete_appraisal_letters.py
@@ -56,12 +56,12 @@ class MyTestCase(unittest.TestCase):
                      '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework'],
                     [os.path.join(input_directory, 'documents', 'objects', '200002.txt'),
                      '0.0', today, today, 'F270E85FDB08BDB6B7BE83270F077E6B', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for deletion, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for deletion, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = []
-        self.assertEqual(result, expected, "Problem with test for deletion, directory contents")
+        self.assertEqual(expected, result, "Problem with test for deletion, directory contents")
 
     def test_file_not_found(self):
         """Test for when the file paths in the metadata do not match files in the export"""
@@ -82,12 +82,12 @@ class MyTestCase(unittest.TestCase):
                      'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError'],
                     [os.path.join(input_directory, 'documents', 'objects', '900000.txt'),
                      'nan', 'nan', 'nan', 'nan', 'Cannot delete: FileNotFoundError']]
-        self.assertEqual(result, expected, "Problem with test for file not found, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for file not found, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['100001.txt', 'ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for file not found, directory contents")
+        self.assertEqual(expected, result, "Problem with test for file not found, directory contents")
 
     def test_new_pattern(self):
         """Test for when the file paths in the metadata match files in the export but are a new pattern"""
@@ -110,12 +110,12 @@ class MyTestCase(unittest.TestCase):
                      'Cannot determine file path: new path pattern in metadata'],
                     ['..\\letters\\200002.txt', 'nan', 'nan', 'nan', 'nan',
                      'Cannot determine file path: new path pattern in metadata']]
-        self.assertEqual(result, expected, "Problem with test for no deletion - form, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for no deletion - form, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['100001.txt', '200002.txt']
-        self.assertEqual(result, expected, "Problem with test for no deletion - form, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no deletion - form, directory contents")
 
     def test_no_deletion_blank(self):
         """Test for when the file paths in the metadata are blank"""
@@ -133,12 +133,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for no deletion - blank, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for no deletion - blank, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for no deletion - blank, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no deletion - blank, directory contents")
 
     def test_no_deletion_empty_string(self):
         """Test for when the file paths in the metadata are empty strings"""
@@ -156,12 +156,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for no deletion - empty string, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for no deletion - empty string, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['ABC-1.txt']
-        self.assertEqual(result, expected, "Problem with test for no deletion - empty string, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no deletion - empty string, directory contents")
 
     def test_no_deletion_form(self):
         """Test for when the file paths in the metadata match files in the export but are form letters (not deleted)"""
@@ -180,12 +180,12 @@ class MyTestCase(unittest.TestCase):
         log_path = os.path.join(output_directory, f'file_deletion_log_{today}.csv')
         result = csv_to_list(log_path)
         expected = [['File', 'SizeKB', 'DateCreated', 'DateDeleted', 'MD5', 'Notes']]
-        self.assertEqual(result, expected, "Problem with test for no deletion - form, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for no deletion - form, file deletion log")
 
         # Tests that no files have been deleted.
         result = files_in_dir(input_directory)
         expected = ['100001.txt', '200002.txt']
-        self.assertEqual(result, expected, "Problem with test for no deletion - form, directory contents")
+        self.assertEqual(expected, result, "Problem with test for no deletion - form, directory contents")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_find_academy_rows.py
+++ b/tests/css_data_interchange_format/test_find_academy_rows.py
@@ -30,13 +30,13 @@ class MyTestCase(unittest.TestCase):
                     ['20250402', 'Academy2025', 'docs\\doc.txt', '', '', 'Academy_Application'],
                     ['20250403', 'academy interviews 25', 'docs\\academy_interviews.txt', '', '', 'Academy_Application'],
                     ['20250404', 'Admin', 'docs\\ACADEMY\\doc.txt', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for both, df_academy")
+        self.assertEqual(expected, result, "Problem with test for both, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250405', 'Admin', 'docs\\doc.txt', 'academy_day.txt', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for both, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for both, df_academy_check")
 
     def test_doc_name(self):
         """Test for when the column communication_document_name indicates academy applications are present"""
@@ -57,12 +57,12 @@ class MyTestCase(unittest.TestCase):
                     ['20250403', 'Admin', 'docs\\academy_interviews.txt', '', '', 'Academy_Application'],
                     ['20250404', 'Admin', 'docs\\ACADEMY\\doc.txt', '', '', 'Academy_Application'],
                     ['20250405', 'Admin', 'docs\\25Academy.txt', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_academy")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_academy_check")
 
     def test_group_name(self):
         """Test for when the column group_name indicates academy applications are present"""
@@ -83,12 +83,12 @@ class MyTestCase(unittest.TestCase):
                     ['20250402', 'Academy2025', 'docs\\doc.txt', '', '', 'Academy_Application'],
                     ['20250403', 'academy interviews 25', 'docs\\doc', '', '', 'Academy_Application'],
                     ['20250406', 'BoardAcademy', '', '', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_academy")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_academy_check")
 
     def test_none(self):
         """Test for no patterns indicating academy applications are present"""
@@ -102,14 +102,14 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_academy are correct.
         result = df_to_list(df_academy)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_academy")
+        self.assertEqual(expected, result, "Problem with test for none, df_academy")
 
         # Tests the values in df_academy_check are correct.
         result = df_to_list(df_academy_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250401', 'Admin', 'docs\\doc.txt', 'academy_file.txt', '', 'Academy_Application'],
                     ['20250403', 'Interviews', 'docs\\doc.txt', 'intACADEMY.txt', '', 'Academy_Application']]
-        self.assertEqual(result, expected, "Problem with test for none, df_academy_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_academy_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_find_appraisal_rows.py
+++ b/tests/css_data_interchange_format/test_find_appraisal_rows.py
@@ -43,12 +43,12 @@ class MyTestCase(unittest.TestCase):
                      'Casework|Job_Application'],
                     ['20240404', 'academy02', r'..\documents\casework\good job.doc', 'good job.doc',
                      'Academy_Application|Casework|Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for all - multiple, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for all - multiple, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -61,7 +61,7 @@ class MyTestCase(unittest.TestCase):
                      'Casework|Job_Application'],
                     ['20240404', 'academy02', r'..\documents\casework\good job.doc', 'good job.doc', 'x',
                      'Academy_Application|Casework|Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for all - multiple, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for all - multiple, appraisal_delete_log.csv")
 
     def test_all_single(self):
         """Test for when all appraisal categories are present and each row matches a single category"""
@@ -82,14 +82,14 @@ class MyTestCase(unittest.TestCase):
                     ['20240202', 'Case1', '', '', 'Casework'],
                     ['20240303', 'jobapp', r'..\documents\objects\position.txt', 'position.txt', 'Job_Application'],
                     ['20240505', 'Admin', r'..\documents\objects\intern rec.txt', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for all - single, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20240606', 'Admin', 'nan', 'legal_case.txt', 'x', 'Casework'],
                     ['20240404', 'Arts', 'nan', 'artist recommendation.txt', 'x', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for all - single, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -98,7 +98,7 @@ class MyTestCase(unittest.TestCase):
                     ['20240202', 'Case1', 'nan', 'nan', 'x', 'Casework'],
                     ['20240303', 'jobapp', r'..\documents\objects\position.txt', 'position.txt', 'x', 'Job_Application'],
                     ['20240505', 'Admin', r'..\documents\objects\intern rec.txt', 'nan', 'x', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for all - single, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for all - single, appraisal_delete_log.csv")
 
     def test_one(self):
         """Test for when only one appraisal category is present"""
@@ -119,13 +119,13 @@ class MyTestCase(unittest.TestCase):
                     ['20240202', 'case 2', '', '', 'Casework'],
                     ['20240404', 'Case3', r'..\documents\casework\3.txt', '3.txt', 'Casework'],
                     ['20240506', 'Econ', r'..\documents\casework\3.txt', '3.txt', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for one, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20240505', 'Econ', r'..\documents\objects\case.txt', 'case.txt', 'x', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for one, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
@@ -134,7 +134,7 @@ class MyTestCase(unittest.TestCase):
                     ['20240202', 'case 2', 'nan', 'nan', 'x', 'Casework'],
                     ['20240404', 'Case3', r'..\documents\casework\3.txt', '3.txt', 'x', 'Casework'],
                     ['20240506', 'Econ', r'..\documents\casework\3.txt', '3.txt', 'x', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for one, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for one, appraisal_delete_log.csv")
 
     def test_none(self):
         """Test for when no rows match any appraisal categories"""
@@ -148,17 +148,17 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in appraisal_df are correct.
         result = df_to_list(appraisal_df)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for something, appraisal_df")
+        self.assertEqual(expected, result, "Problem with test for something, appraisal_df")
 
         # Tests the values in appraisal_check_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_check_log.csv'))
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for something, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for something, appraisal_check_log.csv")
 
         # Tests the values in appraisal_delete_log.csv are correct.
         result = csv_to_list(os.path.join('test_data', 'appraisal_delete_log.csv'))
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for something, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for something, appraisal_delete_log.csv")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_find_casework_rows.py
+++ b/tests/css_data_interchange_format/test_find_casework_rows.py
@@ -30,12 +30,12 @@ class MyTestCase(unittest.TestCase):
                     ['20250401', 'Admin', 'doc\\Casework - Initial Reply.doc', '', '', 'Casework'],
                     ['20250404', 'Admin', 'doc\\initialssacase.doc', '', '', 'Casework'],
                     ['20250405', 'Admin', 'doc\\Close Favorably - Casework.doc', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for both, df_casework")
+        self.assertEqual(expected, result, "Problem with test for both, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for both, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for both, df_casework_check")
 
     def test_doc_name(self):
         """Test for when the column communication_document_name indicates casework is present"""
@@ -65,7 +65,7 @@ class MyTestCase(unittest.TestCase):
                     ['20250406', 'Admin', 'doc\\Open Sixth District Casework.doc', '', '', 'Casework'],
                     ['20250408', 'Admin', 'doc\\initialssacase.doc', '', '', 'Casework'],
                     ['20250409', 'Admin', 'doc\\Open Sixth District Cases.doc', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for both, df_casework")
+        self.assertEqual(expected, result, "Problem with test for both, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
@@ -73,7 +73,7 @@ class MyTestCase(unittest.TestCase):
                     ['20250407', 'Admin', 'doc\\Napster Case.doc', '', '', 'Casework'],
                     ['20250410', 'Admin', 'doc\\Antitrust Case.doc', '', '', 'Casework'],
                     ['20250411', 'Admin', 'doc\\doc.txt', 'case_file.txt', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for both, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for both, df_casework_check")
 
     def test_group_name(self):
         """Test for when the column group_name indicates casework is present"""
@@ -90,14 +90,14 @@ class MyTestCase(unittest.TestCase):
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250401', 'case12', 'doc\\doc.txt', '', '', 'Casework'],
                     ['20250402', 'CASE 1', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_casework")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250403', 'legal case concern', '', '', '', 'Casework'],
                     ['20250404', 'Smith Case', '', '', '', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_casework_check")
 
     def test_none(self):
         """Test for when no patterns indicating casework are present"""
@@ -112,12 +112,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_casework are correct.
         result = df_to_list(df_casework)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_casework")
+        self.assertEqual(expected, result, "Problem with test for none, df_casework")
 
         # Tests the values in df_casework_check are correct.
         result = df_to_list(df_casework_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_casework_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_casework_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_find_job_rows.py
+++ b/tests/css_data_interchange_format/test_find_job_rows.py
@@ -31,12 +31,12 @@ class MyTestCase(unittest.TestCase):
                     ['20250403', 'RESUME', 'docs\\first reply to resume.txt', '', '', 'Job_Application'],
                     ['20250404', 'jobapps2', 'docs\\doc.txt', '', '', 'Job_Application'],
                     ['20250405', 'Admin', 'docs\\job.doc', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for all, df_job")
+        self.assertEqual(expected, result, "Problem with test for all, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for all, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for all, df_job_check")
 
     def test_doc_name(self):
         """Test for when the column communication_document_name indicates job applications are present"""
@@ -58,14 +58,14 @@ class MyTestCase(unittest.TestCase):
                     ['20250402', 'Admin', 'docs\\JOBAPPS.txt', '', '', 'Job_Application'],
                     ['20250403', 'Admin', 'docs\\First Reply to Resume.txt', '', '', 'Job_Application'],
                     ['20250405', 'Admin', 'docs\\Interns - Thank you for resume.doc', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_job")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250406', 'Admin', 'docs\\Jobs Act.txt', 'jobsact.txt', '', 'Job_Application'],
                     ['20250407', 'Admin', 'docs\\Jobs Act.txt', 'jobsact.txt', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_job_check")
 
     def test_group_name(self):
         """Test for when the column group_name indicates job applications are present"""
@@ -87,14 +87,14 @@ class MyTestCase(unittest.TestCase):
                     ['20250403', 'JobApp2', 'docs\\doc.txt', '', '', 'Job_Application'],
                     ['20250404', 'Job Request', '', '', '', 'Job_Application'],
                     ['20250406', 'RESUME', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_job")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250405', 'Jobs Act', '', '', '', 'Job_Application'],
                     ['20250407', 'econ_jobs', '', '', '', 'Job_Application']]
-        self.assertEqual(result, expected, "Problem with test for group_name, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for group_name, df_job_check")
 
     def test_none(self):
         """Test for no patterns indicating job applications are present"""
@@ -108,12 +108,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_job are correct.
         result = df_to_list(df_job)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_job")
+        self.assertEqual(expected, result, "Problem with test for none, df_job")
 
         # Tests the values in df_job_check are correct.
         result = df_to_list(df_job_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_job_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_job_check")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_find_recommendation_rows.py
+++ b/tests/css_data_interchange_format/test_find_recommendation_rows.py
@@ -30,14 +30,14 @@ class MyTestCase(unittest.TestCase):
                     ['20250401', 'Admin', 'docs\\Intern Rec.txt', '', '', 'Recommendation'],
                     ['20250402', 'Admin', 'docs\\PAGE REC.txt', '', '', 'Recommendation'],
                     ['20250403', 'Admin', 'docs\\intern rec-no', '', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_rec")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_rec")
 
         # Tests the values in df_rec_check are correct.
         result = df_to_list(df_rec_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category'],
                     ['20250404', 'Admin', 'docs\\doc.txt', 'page recommendation', '', 'Recommendation'],
                     ['20250406', 'Admin', 'docs\\doc.txt', 'intern recommendation', '', 'Recommendation']]
-        self.assertEqual(result, expected, "Problem with test for doc_name, df_rec_check")
+        self.assertEqual(expected, result, "Problem with test for doc_name, df_rec_check")
 
     def test_none(self):
         """Test for no patterns indicating recommendations are present"""
@@ -51,12 +51,12 @@ class MyTestCase(unittest.TestCase):
         # Tests the values in df_rec are correct.
         result = df_to_list(df_rec)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_rec")
+        self.assertEqual(expected, result, "Problem with test for none, df_rec")
 
         # Tests the values in df_rec_check are correct.
         result = df_to_list(df_rec_check)
         expected = [['date_in', 'group_name', 'communication_document_name', 'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for none, df_rec_check")
+        self.assertEqual(expected, result, "Problem with test for none, df_rec_check")
         
         
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_form_letter_metadata.py
+++ b/tests/css_data_interchange_format/test_form_letter_metadata.py
@@ -41,7 +41,7 @@ class MyTestCase(unittest.TestCase):
                      r'..\doc\formletter\court.pdf', 'JSmith', '17', 'JSmith', '20101212', '20110101', '20150101',
                      'Inactive', 'Y', 'Form Letters', 'staff_member', 'Full Name:', 'COURT', 'COM',
                      r'..\doc\formletter\court.pdf', 'JSmith', '20120101', 'text', 'Y', 'court.pdf', 'JSmith']]
-        self.assertEqual(result, expected, "Problem with test for form letter metadata function")
+        self.assertEqual(expected, result, "Problem with test for form letter metadata function")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_read_metadata.py
+++ b/tests/css_data_interchange_format/test_read_metadata.py
@@ -38,7 +38,7 @@ class MyTestCase(unittest.TestCase):
                      'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan'],
                     ['Macon', 'GA', '31204-3904', 'USA', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan',
                      'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for function read_metadata")
+        self.assertEqual(expected, result, "Problem with test for function read_metadata")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_remove_appraisal_rows.py
+++ b/tests/css_data_interchange_format/test_remove_appraisal_rows.py
@@ -28,7 +28,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['zip_code', 'date_in', 'response_type', 'group_name'],
                     ['30144-2248', '19990301', 'imail', 'TAX1'],
                     ['30062-1613', '19990607', 'usmail', 'TAX1']]
-        self.assertEqual(result, expected, "Problem with test for function")
+        self.assertEqual(expected, result, "Problem with test for function")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_remove_pii.py
+++ b/tests/css_data_interchange_format/test_remove_pii.py
@@ -23,11 +23,11 @@ class MyTestCase(unittest.TestCase):
 
         # Tests the columns of the returned dataframe are correct.
         expected = ['person_id', 'city', 'state_code', 'zip_code', 'country']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 1B, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 1B, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '13', '14', '15', '18']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 1B, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 1B, values")
 
     def test_2a(self):
         """Test for columns in table 2A."""
@@ -44,11 +44,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the columns of the returned dataframe are correct.
         expected = ['person_id', 'communication_id', 'communication_type', 'approved_by', 'status', 'date_in',
                     'date_out', 'reminder_date', 'update_date', 'response_type', 'group_name']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 2A, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 2A, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '3', '6', '8', '9', '10', '11', '12', '13', '14', '19']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 2A, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 2A, values")
 
     def test_2c(self):
         """Test for columns in table 2C."""
@@ -62,11 +62,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the columns of the returned dataframe are correct.
         expected = ['person_id', 'communication_id', 'document_type', 'communication_document_name',
                     'communication_document_id', 'file_location', 'file_name']
-        self.assertEqual(md_df.columns.tolist(), expected, "Problem with test for 2C, columns")
+        self.assertEqual(expected, md_df.columns.tolist(), "Problem with test for 2C, columns")
 
         # Tests the values in the returned dataframe are correct.
         expected = [['2', '3', '4', '5', '6', '7', '8']]
-        self.assertEqual(md_df.values.tolist(), expected, "Problem with test for 2C, values")
+        self.assertEqual(expected, md_df.values.tolist(), "Problem with test for 2C, values")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_script.py
+++ b/tests/css_data_interchange_format/test_script.py
@@ -76,7 +76,7 @@ class MyTestCase(unittest.TestCase):
         expected = ('\nThe script is running in access mode.\nIt will remove rows for deleted letters '
                     'and columns with PII, make copies of the metadata split by congress year, '
                     'and make a copy of the constituent letters organized by topic\n')
-        self.assertEqual(result, expected, "Problem with test for access, printed statement")
+        self.assertEqual(expected, result, "Problem with test for access, printed statement")
 
         # Tests the contents of the appraisal_check_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -85,7 +85,7 @@ class MyTestCase(unittest.TestCase):
                      'date_in', 'date_out', 'reminder_date', 'update_date', 'response_type', 'group_name',
                      'document_type', 'communication_document_name', 'communication_document_id', 'file_location',
                      'file_name', 'text', 'Appraisal_Category']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal_check_log.csv")
 
         # Tests the contents of the appraisal_delete_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -97,7 +97,7 @@ class MyTestCase(unittest.TestCase):
                     [' ', ' ', 'nan', 'POLAND', 'usmail', 'nan', 'C', '19990315', '19990402', 'nan', '19990315',
                      'usmail', 'CASEWORK', 'OUTGOING', r'..\documents\indivletters\2070078.doc', '2070078.doc',
                      ' ', 'nan', 'Neutral', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for access, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for access, appraisal_delete_log.csv")
 
         # Tests the contents of archiving_correspondence_redacted.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_redacted.csv')
@@ -128,7 +128,7 @@ class MyTestCase(unittest.TestCase):
                     ['Washington', 'DC', '20420-0002', 'USA', 'nan', '513', 'C', '19990721', '19990721', 'nan',
                      '19990721', 'imail', 'nan', 'OUTGOING', r'..\documents\formletters\208956.html', '208956',
                      ' ', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, archiving_correspondence_redacted.csv")
+        self.assertEqual(expected, result, "Problem with test for access, archiving_correspondence_redacted.csv")
 
         # Tests the contents of form_letter_metadata.csv.
         csv_path = os.path.join('test_data', 'script', 'form_letter_metadata.csv')
@@ -150,7 +150,7 @@ class MyTestCase(unittest.TestCase):
                      r'..\doc\formletter\court.pdf', 'JSmith', '17', 'JSmith', '20101212', '20110101', '20150101',
                      'Inactive', 'Y', 'Form Letters', 'staff_member', 'Full Name:', 'COURT', 'COM',
                      r'..\doc\formletter\court.pdf', 'JSmith', '20120101', 'text', 'Y', 'court.pdf', 'JSmith']]
-        self.assertEqual(result, expected, "Problem with test for access, form_letter_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for access, form_letter_metadata.csv")
 
         # Tests the contents of 1999-2000.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '1999-2000.csv')
@@ -174,7 +174,7 @@ class MyTestCase(unittest.TestCase):
                     ['Washington', 'DC', '20420-0002', 'USA', 'nan', '513', 'C', '19990721', '19990721', 'nan',
                      '19990721', 'imail', 'nan', 'OUTGOING', r'..\documents\formletters\208956.html', '208956',
                      ' ', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, 1999-2000.csv")
+        self.assertEqual(expected, result, "Problem with test for access, 1999-2000.csv")
 
         # Tests the contents of 2011-2012.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', '2011-2012.csv')
@@ -186,7 +186,7 @@ class MyTestCase(unittest.TestCase):
                     ['Marietta', 'GA', '30062-1668', 'USA', 'nan', '513', 'C', '20120914', '20120914', 'nan',
                      '20120914', 'imail', 'nan', 'OUTGOING', r'..\documents\formletters\2103422.html',
                      '2103422', ' ', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, 2011-2012.csv")
+        self.assertEqual(expected, result, "Problem with test for access, 2011-2012.csv")
 
         # Tests the contents of undated.csv.
         csv_path = os.path.join('test_data', 'script', 'archiving_correspondence_by_congress_year', 'undated.csv')
@@ -200,13 +200,13 @@ class MyTestCase(unittest.TestCase):
                     ['Smyrna', 'GA', '30080-1944', 'USA', 'usmail', 'nan', 'C', 'nan', 'nan', 'nan', 'nan', 'usmail',
                      'nan', 'OUTGOING', r'..\documents\formletters\Airline Passenger BOR Act2 1999.doc',
                      'Airline Passenger BOR Act2 1999', ' ', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for access, undated.csv")
+        self.assertEqual(expected, result, "Problem with test for access, undated.csv")
 
         # Tests that Correspondence_by_Topic has the expected files.
         by_topic = os.path.join(os.getcwd(), 'test_data', 'script', 'Correspondence_by_Topic')
         result = make_dir_list(by_topic)
         expected = [os.path.join(by_topic, 'FARMING', '4007000.eml')]
-        self.assertEqual(result, expected, "Problem with test for access, Correspondence_by_Topic")
+        self.assertEqual(expected, result, "Problem with test for access, Correspondence_by_Topic")
 
     def test_accession(self):
         """Test for when the script runs correctly in accession mode."""
@@ -220,7 +220,7 @@ class MyTestCase(unittest.TestCase):
         result = output.stdout
         expected = ('\nThe script is running in accession mode.\n'
                     'It will produce usability and appraisal reports and not change the export.\n')
-        self.assertEqual(result, expected, "Problem with test for accession, printed statement")
+        self.assertEqual(expected, result, "Problem with test for accession, printed statement")
 
         # Tests the contents of the appraisal_check_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -232,7 +232,7 @@ class MyTestCase(unittest.TestCase):
                     ['Washington', 'DC', '20420-0002', 'USA', 'nan', '513', 'C', '19990721', '19990721', 'nan',
                      '19990721', 'imail', 'nan', 'OUTGOING', r'..\documents\formletters\legal_case.html',
                      'legal_case.html', ' ', 'nan', 'text8', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for accession, appraisal_check_log.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, appraisal_check_log.csv")
 
         # Tests the contents of the appraisal_delete_log.csv.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -256,7 +256,7 @@ class MyTestCase(unittest.TestCase):
                     ['Marietta', 'Georgia', '30062-1668', 'USA', 'nan', '551', 'C', '19990315', '19990402', 'nan',
                      '19990315', 'imail', 'CASE2', 'INCOMING', r'..\documents\objects\4007000.eml', 'nan',
                      '1c8614bf01caf83e00010e44.eml', 'nan', 'text7', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for accession, appraisal_delete_log.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, appraisal_delete_log.csv")
 
         # Tests the contents of the metadata_formatting_errors_update_date.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_update_date.csv')
@@ -271,7 +271,7 @@ class MyTestCase(unittest.TestCase):
                     ['Marietta', 'GA', '30067-8581', 'USA', 'nan', '513', 'C', '20000427', '20000427', 'nan',
                      '2000 April 27', 'imail', 'nan', 'OUTGOING', r'..\documents\indivletters\casework_12345.doc',
                      'nan', ' ', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_update_date.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_update_date.csv")
 
         # Tests the contents of the metadata_formatting_errors_state_code.csv.
         csv_path = os.path.join('test_data', 'script', 'metadata_formatting_errors_state_code.csv')
@@ -291,7 +291,7 @@ class MyTestCase(unittest.TestCase):
                     ['Marietta', 'Georgia', '30062-1668', 'USA', 'nan', '551', 'C', '19990315', '19990402', 'nan',
                      '19990315', 'imail', 'CASE2', 'INCOMING', r'..\documents\objects\4007000.eml', 'nan',
                      '1c8614bf01caf83e00010e44.eml', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for accession, metadata_formatting_errors_state_code.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, metadata_formatting_errors_state_code.csv")
 
         # Tests the contents of the topics_report.csv.
         csv_path = os.path.join('test_data', 'script', 'topics_report.csv')
@@ -301,7 +301,7 @@ class MyTestCase(unittest.TestCase):
                     ['CASE2', '3'],
                     ['CASE 1', '1'],
                     ['INTTAX', '1']]
-        self.assertEqual(result, expected, "Problem with test for accession, topics_report.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, topics_report.csv")
 
         # Tests the contents of the usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
@@ -311,7 +311,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata_Only', '3', '33%'],
                     ['Metadata_Blank', '0', '0%'],
                     ['Directory_Only', '1', 'nan']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of the usability_report_matching_details.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching_details.csv')
@@ -322,7 +322,7 @@ class MyTestCase(unittest.TestCase):
                     ['Metadata Only', r'test_data\script\accession_test\documents\formletters\airline act2.doc'],
                     ['Metadata Only', r'test_data\script\accession_test\documents\formletters\busintax.doc'],
                     ['Metadata Only', r'test_data\script\accession_test\documents\indivletters\00002.doc']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_matching_details.csv")
 
         # Tests the contents of the usability_report_metadata.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_metadata.csv')
@@ -346,7 +346,7 @@ class MyTestCase(unittest.TestCase):
                     ['communication_document_id', 'True', '2', '22.22', 'uncheckable'],
                     ['file_location', 'True', '0', '0.0', 'uncheckable'],
                     ['file_name', 'True', '9', '100.0', 'uncheckable']]
-        self.assertEqual(result, expected, "Problem with test for accession, usability_report_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for accession, usability_report_metadata.csv")
 
     def test_appraisal(self):
         """Test for when the script runs correctly in appraisal mode."""
@@ -364,7 +364,7 @@ class MyTestCase(unittest.TestCase):
         result = output.stdout
         expected = ('\nThe script is running in appraisal mode.\n'
                     'It will delete letters due to appraisal but not change the metadata file.\n')
-        self.assertEqual(result, expected, "Problem with test for appraisal, printed statement")
+        self.assertEqual(expected, result, "Problem with test for appraisal, printed statement")
 
         # Tests the contents of the appraisal check log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_check_log.csv')
@@ -376,7 +376,7 @@ class MyTestCase(unittest.TestCase):
                     ['Washington', 'DC', '20420-0002', 'USA', 'nan', '513', 'C', '19990721', '19990721', 'nan',
                      '19990721', 'imail', 'nan', 'OUTGOING', r'..\documents\formletters\legal_case.html',
                      'legal_case.html', ' ', 'nan', 'text8', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal check log")
+        self.assertEqual(expected, result, "Problem with test for appraisal check log")
 
         # Tests the contents of the appraisal delete log.
         csv_path = os.path.join('test_data', 'script', 'appraisal_delete_log.csv')
@@ -400,7 +400,7 @@ class MyTestCase(unittest.TestCase):
                     ['Marietta', 'GA', '30067-8581', 'USA', 'nan', '513', 'C', '20000427', '20000427', 'nan',
                      '20000427', 'imail', 'nan', 'OUTGOING', r'..\documents\indivletters\casework_12345.doc',
                      'nan', ' ', 'nan', 'text5', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, appraisal delete log")
+        self.assertEqual(expected, result, "Problem with test for appraisal, appraisal delete log")
 
         # Tests the contents of the file deletion log.
         today = date.today().strftime('%Y-%m-%d')
@@ -415,13 +415,13 @@ class MyTestCase(unittest.TestCase):
                      '0.0', today, today, '49C13D076A41E65DBE137D695E22A6A7', 'Casework'],
                     [r'..\documents\indivletters\casework_12345.doc'.replace('..', input_directory),
                      '26.6', today, today, 'A9C52FA2BA1A0E51AD59DA2E4DA08C9D', 'Casework']]
-        self.assertEqual(result, expected, "Problem with test for appraisal, file deletion log")
+        self.assertEqual(expected, result, "Problem with test for appraisal, file deletion log")
 
         # Tests the contents of the input_directory, that all files that should be deleted are gone.
         result = files_in_dir(input_directory)
         expected = ['out_1B.dat', 'out_2A.dat', 'out_2C.dat', 'out_2D.dat',
                     '2103422.html', '30046.doc', 'legal_case.html']
-        self.assertEqual(result, expected, "Problem with test for appraisal, input_directory contents")
+        self.assertEqual(expected, result, "Problem with test for appraisal, input_directory contents")
 
     def test_error_argument(self):
         """Test for when the script exits due to an argument error."""
@@ -435,7 +435,7 @@ class MyTestCase(unittest.TestCase):
         output = subprocess.run(f"python {script_path}", shell=True, stdout=subprocess.PIPE)
         result = output.stdout.decode('utf-8')
         expected = "Missing required arguments, input_directory and script_mode\r\n"
-        self.assertEqual(result, expected, "Problem with test for error argument, printed error")
+        self.assertEqual(expected, result, "Problem with test for error argument, printed error")
 
     def test_preservation(self):
         """Test for when the script runs correctly in preservation mode."""
@@ -449,7 +449,7 @@ class MyTestCase(unittest.TestCase):
         # Tests the print statement.
         result = output.stdout
         expected = '\nThe script is running in preservation mode.\nThe steps are TBD.\n'
-        self.assertEqual(result, expected, "Problem with test for preservation, printed statement")
+        self.assertEqual(expected, result, "Problem with test for preservation, printed statement")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_script.py
+++ b/tests/css_data_interchange_format/test_script.py
@@ -306,11 +306,11 @@ class MyTestCase(unittest.TestCase):
         # Tests the contents of the usability_report_matching.csv.
         csv_path = os.path.join('test_data', 'script', 'usability_report_matching.csv')
         result = csv_to_list(csv_path)
-        expected = [['Category', 'Count'],
-                    ['Metadata_Only', '3'],
-                    ['Directory_Only', '1'],
-                    ['Match', '6'],
-                    ['Metadata_Blank', '0']]
+        expected = [['Category', 'Row/File_Count', 'Row_Percent'],
+                    ['Match', '6', '67%'],
+                    ['Metadata_Only', '3', '33%'],
+                    ['Metadata_Blank', '0', '0%'],
+                    ['Directory_Only', '1', 'nan']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching.csv")
 
         # Tests the contents of the usability_report_matching_details.csv.
@@ -319,7 +319,7 @@ class MyTestCase(unittest.TestCase):
         result.sort()
         expected = [['Category', 'Path'],
                     ['Directory Only', r'test_data\script\accession_test\documents\indivletters\casework_999999.doc'],
-                    ['Metadata Only', r'test_data\script\accession_test\documents\formletters\Airline Act2.doc'],
+                    ['Metadata Only', r'test_data\script\accession_test\documents\formletters\airline act2.doc'],
                     ['Metadata Only', r'test_data\script\accession_test\documents\formletters\busintax.doc'],
                     ['Metadata Only', r'test_data\script\accession_test\documents\indivletters\00002.doc']]
         self.assertEqual(result, expected, "Problem with test for accession, usability_report_matching_details.csv")

--- a/tests/css_data_interchange_format/test_sort_correspondence.py
+++ b/tests/css_data_interchange_format/test_sort_correspondence.py
@@ -63,7 +63,7 @@ class MyTestCase(unittest.TestCase):
         # Verifies the expected topic folders were created and have the expected files in them.
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for blank")
+        self.assertEqual(expected, result, "Problem with test for blank")
 
     def test_duplicate_file(self):
         """Test for when a file is in the metadata with the same topic more than once"""
@@ -78,7 +78,7 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'dogs', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_file")
+        self.assertEqual(expected, result, "Problem with test for duplicate_file")
 
     def test_duplicate_topic(self):
         """Test for when a topic is in the metadata more than once"""
@@ -95,7 +95,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'cats', 'file3.txt'),
                     os.path.join(self.by_topic, 'cats', 'file4.txt'),
                     os.path.join(self.by_topic, 'dogs', 'file2.txt')]
-        self.assertEqual(result, expected, "Problem with test for duplicate_topic")
+        self.assertEqual(expected, result, "Problem with test for duplicate_topic")
 
     def test_filenotfounderror(self):
         """Test for when a file is in the metadata but not the directory"""
@@ -110,13 +110,13 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, topic folders")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
         expected = [['dogs', r'..\documents\ima\file2.txt'],
                     ['park', r'\doc\objects\file4.txt']]
-        self.assertEqual(result, expected, "Problem with test for filenotfounderror, log")
+        self.assertEqual(expected, result, "Problem with test for filenotfounderror, log")
 
     def test_folder_empty(self):
         """Test for when no files for a topic are in the directory and the topic folder is empty"""
@@ -131,19 +131,19 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'farm', 'file3.txt'),
                     os.path.join(self.by_topic, 'park', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder empty, topic folders")
+        self.assertEqual(expected, result, "Problem with test for folder empty, topic folders")
 
         # Verifies the expected log was created and has the expected contents.
         result = make_log_list()
         expected = [['cats', r'..\documents\file1.txt'],
                     ['dogs', r'..\documents\file2.txt']]
-        self.assertEqual(result, expected, "Problem with test for folder empty, log")
+        self.assertEqual(expected, result, "Problem with test for folder empty, log")
 
         # Verifies folders without a file are not still present.
         result = [os.path.exists(os.path.join(self.by_topic, 'cats')),
                   os.path.exists(os.path.join(self.by_topic, 'dogs'))]
         expected = [False, False]
-        self.assertEqual(result, expected, "Problem with test for folder empty, folders not deleted")
+        self.assertEqual(expected, result, "Problem with test for folder empty, folders not deleted")
 
     def test_folder_name_error(self):
         """Test for when a topic contains a character that cannot be in a folder name"""
@@ -160,7 +160,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'Ga_', 'file2.txt'),
                     os.path.join(self.by_topic, '_H_', 'file3.txt'),
                     os.path.join(self.by_topic, '_pa_rk_', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name error")
+        self.assertEqual(expected, result, "Problem with test for folder name error")
 
     def test_folder_name_trailing(self):
         """Test for when a topic ends with a space or period, which cannot be in the folder name"""
@@ -177,7 +177,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'cat', 'file2.txt'),
                     os.path.join(self.by_topic, 'dog', 'file3.txt'),
                     os.path.join(self.by_topic, 'park and rec', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for folder name trailing")
+        self.assertEqual(expected, result, "Problem with test for folder name trailing")
 
     def test_outgoing(self):
         """Test for when some rows are for outgoing correspondence and should be skipped"""
@@ -192,7 +192,7 @@ class MyTestCase(unittest.TestCase):
         result = make_dir_list(self.by_topic)
         expected = [os.path.join(self.by_topic, 'cats', 'file1.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt')]
-        self.assertEqual(result, expected, "Problem with test for outgoing")
+        self.assertEqual(expected, result, "Problem with test for outgoing")
 
     def test_unique(self):
         """Test for when topic and file is unique"""
@@ -209,7 +209,7 @@ class MyTestCase(unittest.TestCase):
                     os.path.join(self.by_topic, 'dogs', 'file2.txt'),
                     os.path.join(self.by_topic, 'farm', 'file3.txt'),
                     os.path.join(self.by_topic, 'park', 'file4.txt')]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_split_congress_year.py
+++ b/tests/css_data_interchange_format/test_split_congress_year.py
@@ -36,20 +36,20 @@ class MyTestCase(unittest.TestCase):
                     ['MI', '49068-1164', '19980412', 'INSUTAX2'],
                     ['VA', '22031-4339', '19970412', 'TOUR'],
                     ['GA', '30082-1838', '19970412', 'SSCUTS2']]
-        self.assertEqual(result, expected, "Problem with test for all year variations, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for all year variations, 1997-1998")
 
         # Tests that 2011-2012.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2011-2012.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['GA', '30152-3929', '20121130', 'SSCUTS1']]
-        self.assertEqual(result, expected, "Problem with test for all year variations, 2011-2012")
+        self.assertEqual(expected, result, "Problem with test for all year variations, 2011-2012")
 
         # Tests that undated.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['GA', '30102-1056', 'nan', 'nan'],
                     ['GA', '30062-2748', 'nan', 'INSUTAX1']]
-        self.assertEqual(result, expected, "Problem with test for all year variations, undated.csv")
+        self.assertEqual(expected, result, "Problem with test for all year variations, undated.csv")
 
     def test_date_blank(self):
         """Test for when some of the letters do not have a date (date_in column is blank)"""
@@ -64,7 +64,7 @@ class MyTestCase(unittest.TestCase):
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['GA', '30102-1056', 'nan', 'nan'],
                     ['GA', '30062-2748', 'nan', 'INSUTAX1']]
-        self.assertEqual(result, expected, "Problem with test for blank years, undated.csv")
+        self.assertEqual(expected, result, "Problem with test for blank years, undated.csv")
 
     def test_even_years(self):
         """Test for when the letters are from even numbered years"""
@@ -79,18 +79,18 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '1997-1998.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['MI', '49068-1164', '19980412', 'INSUTAX2']]
-        self.assertEqual(result, expected, "Problem with test for even years, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for even years, 1997-1998")
 
         # Tests that 2011-2012.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2011-2012.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['GA', '30152-3929', '20121130', 'SSCUTS1'],
                     ['FL', '32448-5365', '20121231', 'SSCUTS1']]
-        self.assertEqual(result, expected, "Problem with test for even years, 2011-2012")
+        self.assertEqual(expected, result, "Problem with test for even years, 2011-2012")
 
         # Tests that undated.csv was not made.
         result = os.path.exists(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
-        self.assertEqual(result, False, "Problem with test for even years, undated")
+        self.assertEqual(False, result, "Problem with test for even years, undated")
 
     def test_odd_years(self):
         """Test for when the letters are from odd numbered years"""
@@ -106,17 +106,17 @@ class MyTestCase(unittest.TestCase):
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['VA', '22031-4339', '19970412', 'TOUR'],
                     ['GA', '30082-1838', '19970412', 'SSCUTS2']]
-        self.assertEqual(result, expected, "Problem with test for odd years, 1997-1998")
+        self.assertEqual(expected, result, "Problem with test for odd years, 1997-1998")
 
         # Tests that 2009-2010.csv has the correct values.
         result = csv_to_list(os.path.join('test_data', 'archiving_correspondence_by_congress_year', '2009-2010.csv'))
         expected = [['state_code', 'zip_code', 'date_in', 'group_name'],
                     ['GA', '30328-4628', '20091015', 'TOUR']]
-        self.assertEqual(result, expected, "Problem with test for odd years, 2009-2010")
+        self.assertEqual(expected, result, "Problem with test for odd years, 2009-2010")
 
         # Tests that undated.csv was not made.
         result = os.path.exists(os.path.join('test_data', 'archiving_correspondence_by_congress_year', 'undated.csv'))
-        self.assertEqual(result, False, "Problem with test for odd years, undated")
+        self.assertEqual(False, result, "Problem with test for odd years, undated")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_topics_report.py
+++ b/tests/css_data_interchange_format/test_topics_report.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
                     ['BLANK', '1'],
                     ['Pet Parade', '1'],
                     ['education', '1']]
-        self.assertEqual(result, expected, "Problem with test for all")
+        self.assertEqual(expected, result, "Problem with test for all")
 
     def test_blanks(self):
         """Test for when group is blank"""
@@ -47,7 +47,7 @@ class MyTestCase(unittest.TestCase):
         result = csv_to_list(os.path.join('test_data', 'topics_report.csv'))
         expected = [['Topic', 'Topic_Count'],
                     ['BLANK', '6']]
-        self.assertEqual(result, expected, "Problem with test for blanks")
+        self.assertEqual(expected, result, "Problem with test for blanks")
 
     def test_repeat(self):
         """Test for when groups are repeated"""
@@ -64,7 +64,7 @@ class MyTestCase(unittest.TestCase):
                     ['Farms', '4'],
                     ['Pets', '3'],
                     ['Econ', '2']]
-        self.assertEqual(result, expected, "Problem with test for repeat")
+        self.assertEqual(expected, result, "Problem with test for repeat")
 
     def test_unique(self):
         """Test for when each group is used once"""
@@ -79,7 +79,7 @@ class MyTestCase(unittest.TestCase):
                     ['Econ', '1'],
                     ['farm - aid', '1'],
                     ['pets', '1']]
-        self.assertEqual(result, expected, "Problem with test for unique")
+        self.assertEqual(expected, result, "Problem with test for unique")
 
 
 if __name__ == '__main__':

--- a/tests/css_data_interchange_format/test_update_path.py
+++ b/tests/css_data_interchange_format/test_update_path.py
@@ -11,19 +11,19 @@ class MyTestCase(unittest.TestCase):
         """Test for the pattern ..\\documents\\folder\\..\\file.ext"""
         file_path = update_path(r'..\documents\formletters\form_a.txt', 'input_dir')
         expected = r'input_dir\documents\formletters\form_a.txt'
-        self.assertEqual(file_path, expected, "Problem with test for pattern match")
+        self.assertEqual(expected, file_path, "Problem with test for pattern match")
 
     def test_new(self):
         """Test for a new pattern"""
         file_path = update_path(r'\folder\folder\letter\111111.txt', 'input_dir')
         expected = 'error_new'
-        self.assertEqual(file_path, expected, "Problem with test for new")
+        self.assertEqual(expected, file_path, "Problem with test for new")
 
     def test_new_doc(self):
         """Test for a new pattern that starts with ..\\ still but not documents"""
         file_path = update_path(r'..\folder\111111.txt', 'input_dir')
         expected = 'error_new'
-        self.assertEqual(file_path, expected, "Problem with test for new")
+        self.assertEqual(expected, file_path, "Problem with test for new")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the unit tests for assertEqual, switch the parameter order from result, expected to expected, result to align with how PyCharm labels the comparison on failed tests.