### PR TITLE
Topic sort folder error doesnotexist

### DIFF
--- a/cms_data_interchange_format.py
+++ b/cms_data_interchange_format.py
@@ -574,8 +574,9 @@ def topics_sort_files(df, corr_type_folders, input_dir, output_dir, folder_path)
         doc_path = update_path(doc, input_dir)
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
-        # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc_path == 'error_new' or os.path.isdir(doc_path):
+        # error_new happens when there is data in the document column that cannot be mapped to a path in the export.
+        # Cannot use os.path.isdir() to test for directory because the folder may not exist.
+        if doc_path == 'error_new' or '.' not in doc_path:
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/cms_data_interchange_format.py
+++ b/cms_data_interchange_format.py
@@ -575,7 +575,7 @@ def topics_sort_files(df, corr_type_folders, input_dir, output_dir, folder_path)
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
         # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc == 'error_new' or os.path.isdir(doc):
+        if doc_path == 'error_new' or os.path.isdir(doc_path):
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -717,8 +717,9 @@ def topics_sort_files(df, column, input_dir, output_dir, folder_path):
         doc_path = update_path(doc, input_dir)
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
-        # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc_path == 'error_new' or os.path.isdir(doc_path):
+        # error_new happens when there is data in the document column that cannot be mapped to a path in the export.
+        # Cannot use os.path.isdir() to test for directory because the folder may not exist.
+        if doc_path == 'error_new' or '.' not in doc_path:
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/css_archiving_format.py
+++ b/css_archiving_format.py
@@ -718,7 +718,7 @@ def topics_sort_files(df, column, input_dir, output_dir, folder_path):
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
         # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc == 'error_new' or os.path.isdir(doc):
+        if doc_path == 'error_new' or os.path.isdir(doc_path):
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/css_data_interchange_format.py
+++ b/css_data_interchange_format.py
@@ -655,8 +655,9 @@ def topics_sort_files(df, corr_type, input_dir, output_dir, folder_path):
         doc_path = update_path(doc, input_dir)
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
-        # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc_path == 'error_new' or os.path.isdir(doc_path):
+        # error_new happens when there is data in the document column that cannot be mapped to a path in the export.
+        # Cannot use os.path.isdir() to test for directory because the folder may not exist.
+        if doc_path == 'error_new' or '.' not in doc_path:
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/css_data_interchange_format.py
+++ b/css_data_interchange_format.py
@@ -656,7 +656,7 @@ def topics_sort_files(df, corr_type, input_dir, output_dir, folder_path):
 
         # Skip any path that doesn't match a known pattern (error_new) or if the doc is a directory rather than a file.
         # This happens when there is data in the document column that cannot be mapped to a path in the export.
-        if doc == 'error_new' or os.path.isdir(doc):
+        if doc_path == 'error_new' or os.path.isdir(doc_path):
             continue
 
         # Gets the path for the subfolder for where the doc will be saved,

--- a/tests/css_archiving_format/test_topics_sort_files.py
+++ b/tests/css_archiving_format/test_topics_sort_files.py
@@ -243,19 +243,21 @@ class MyTestCase(unittest.TestCase):
     def test_skip(self):
         """Test for when there are document paths to skip, either a new pattern or for a folder instead of a file"""
         # Makes a dataframe to use as test input and runs the function being tested.
-        df = make_df([['30600', 'ag', '..\\documents\\BlobExport\\forms', 'TBD', 'error_new'],
+        df = make_df([['30600', 'ag', 'new\\pattern\\file.txt', 'TBD', 'new\\pattern\\file.txt'],
                       ['30601', 'ag', '..\\documents\\BlobExport\\forms\\ag.txt', 'TBD',
                        '..\\documents\\BlobExport\\forms\\ag.txt'],
-                      ['30602', 'ag', 'new\\pattern\\file.txt', 'TBD', 'error_new']])
+                      ['30602', 'ag', '..\\documents\\BlobExport\\forms', 'TBD', '..\\documents\\BlobExport\\forms'],
+                      ['30603', 'ag', '..\\documents\\BlobExport\\none', 'TBD', '..\\documents\\BlobExport\\none']])
         df_topic = topics_sort_files(df, 'out_document_name_split', self.input_dir, self.output_dir, self.folder_path)
 
         # Verifies df_topic has the correct values.
         result = df_to_list(df_topic)
         expected = [['zip', 'out_topic', 'out_document_name', 'out_document_name_present', 'out_document_name_split'],
-                    ['30600', 'ag', '..\\documents\\BlobExport\\forms', 'TBD', 'error_new'],
+                    ['30600', 'ag', 'new\\pattern\\file.txt', 'TBD', 'new\\pattern\\file.txt'],
                     ['30601', 'ag', '..\\documents\\BlobExport\\forms\\ag.txt', True,
                      '..\\documents\\BlobExport\\forms\\ag.txt'],
-                    ['30602', 'ag', 'new\\pattern\\file.txt', 'TBD', 'error_new']]
+                    ['30602', 'ag', '..\\documents\\BlobExport\\forms', 'TBD', '..\\documents\\BlobExport\\forms'],
+                    ['30603', 'ag', '..\\documents\\BlobExport\\none', 'TBD', '..\\documents\\BlobExport\\none']]
         self.assertEqual(expected, result, "Problem with test for skip, df_topic")
 
         # Verifies the expected folders were created and have the expected files in them.


### PR DESCRIPTION
Fix skipping directories during topics_sort_files() to work even if the directory does not exist. Also fix the path being tested to use the updated version, not the original from the metadata.